### PR TITLE
Fail string and byte-slice conversions on zero-values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `Value.Bytes()`
+
+### Changed
+
+- **[BC]** Rename `Value.IsEmpty()` to `IsZero()` to better distinguish between unpopulated values and empty content
+- **[BC]** `Value.AsString()` and `AsBytes()` now return an error if the `Value` is the zero-value
+- **[BC]** `Value.String()` now panics if the `Value` is the zero-value
+
 ## [0.1.2] - 2019-11-20
 
 ### Added

--- a/config/bucket.go
+++ b/config/bucket.go
@@ -8,7 +8,7 @@ type EachFunc func(k string, v Value) bool
 type Bucket interface {
 	// Get returns the value associated with the given key.
 	//
-	// If they key is not defined, it returns an empty value.
+	// If they key is not defined, it returns a zero-value.
 	Get(k string) Value
 
 	// GetDefault returns the value associated with the given key.

--- a/config/environment.go
+++ b/config/environment.go
@@ -43,7 +43,7 @@ type environment struct{}
 
 // Get returns the value associated with the given key.
 //
-// If they key is not defined, it returns an empty value.
+// If they key is not defined, it returns a zero-value.
 func (environment) Get(k string) Value {
 	if isDataSource(k) {
 		// never return the value of "source type" variables, they are meta-data
@@ -66,7 +66,7 @@ func (environment) GetDefault(k string, v string) Value {
 
 	x := getenv(k)
 
-	if x.IsEmpty() {
+	if x.IsZero() {
 		return String(v)
 	}
 

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -40,7 +40,7 @@ func ExampleEnvironment_getWithUndefinedVariable() {
 
 	v := config.Environment().Get("FOO")
 
-	fmt.Println(v.IsEmpty())
+	fmt.Println(v.IsZero())
 
 	// Output: true
 }

--- a/config/value.go
+++ b/config/value.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"io"
 	"os"
 )
@@ -10,8 +11,11 @@ type Value struct {
 	src source
 }
 
-// IsEmpty returns true if this value is empty or undefined.
-func (v *Value) IsEmpty() bool {
+// IsZero returns true if this value is the zero-value.
+//
+// This means that the value has no data-source, and not necessarily that the
+// data source will produce an empty value.
+func (v *Value) IsZero() bool {
 	return v.src == nil
 }
 
@@ -50,10 +54,10 @@ func (v Value) AsPath() (string, io.Closer, error) {
 
 // AsString returns the configuration value as a string.
 //
-// If v is the zero-value, it returns an empty string.
+// It returns an error v is the zero-value.
 func (v Value) AsString() (string, error) {
 	if v.src == nil {
-		return "", nil
+		return "", errors.New("can not represent a zero-value as a string")
 	}
 
 	return v.src.AsString()
@@ -64,15 +68,13 @@ func (v Value) AsString() (string, error) {
 // If v is the zero-value, it returns a nil slice.
 func (v Value) AsBytes() ([]byte, error) {
 	if v.src == nil {
-		return nil, nil
+		return nil, errors.New("can not represent a zero-value as a byte-slice")
 	}
 
 	return v.src.AsBytes()
 }
 
 // String returns the value as a string, or panics if unable to do so.
-//
-// If v is the zero-value, it returns an empty string.
 func (v Value) String() string {
 	s, err := v.AsString()
 	if err != nil {
@@ -80,4 +82,14 @@ func (v Value) String() string {
 	}
 
 	return s
+}
+
+// Bytes returns the value as a byte-slice, or panics if unable to do so.
+func (v Value) Bytes() []byte {
+	b, err := v.AsBytes()
+	if err != nil {
+		panic(err)
+	}
+
+	return b
 }

--- a/config/value_test.go
+++ b/config/value_test.go
@@ -1,13 +1,14 @@
 package config_test
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	. "github.com/dogmatiq/dodeca/config"
 )
 
-func TestValue_AsReader_withEmptyValue(t *testing.T) {
+func TestValue_AsReader_withZeroValue(t *testing.T) {
 	_, err := Value{}.AsReader()
 
 	if !os.IsNotExist(err) {
@@ -15,7 +16,7 @@ func TestValue_AsReader_withEmptyValue(t *testing.T) {
 	}
 }
 
-func TestValue_AsPath_withEmptyValue(t *testing.T) {
+func TestValue_AsPath_withZeroValue(t *testing.T) {
 	_, _, err := Value{}.AsPath()
 
 	if !os.IsNotExist(err) {
@@ -23,26 +24,68 @@ func TestValue_AsPath_withEmptyValue(t *testing.T) {
 	}
 }
 
-func TestValue_AsString_withEmptyValue(t *testing.T) {
-	v, err := Value{}.AsString()
+func TestValue_AsString_withZeroValue(t *testing.T) {
+	_, err := Value{}.AsString()
 
-	if err != nil {
-		t.Fatal("unexpected error", err)
-	}
-
-	if v != "" {
-		t.Fatal("unexpected value", v)
+	if err == nil || err.Error() != "can not represent a zero-value as a string" {
+		t.Fatal("unexpected error, got:", err)
 	}
 }
 
-func TestValue_AsBytes_withEmptyValue(t *testing.T) {
-	v, err := Value{}.AsBytes()
+func TestValue_AsBytes_withZeroValue(t *testing.T) {
+	_, err := Value{}.AsBytes()
 
-	if err != nil {
-		t.Fatal("unexpected error", err)
+	if err == nil || err.Error() != "can not represent a zero-value as a byte-slice" {
+		t.Fatal("unexpected error, got:", err)
 	}
+}
 
-	if len(v) != 0 {
-		t.Fatal("unexpected value", v)
+func TestValue_String(t *testing.T) {
+	v := String("<value>").String()
+
+	if v != "<value>" {
+		t.Fatalf("unexpected value: %s", v)
 	}
+}
+
+func TestValue_String_withZeroValue(t *testing.T) {
+	defer func() {
+		p := recover()
+
+		switch e := p.(type) {
+		case error:
+			if e.Error() != "can not represent a zero-value as a string" {
+				t.Fatalf("expected panic did not occur, got: %s", p)
+			}
+		default:
+			t.Fatal("expected panic did not occur")
+		}
+	}()
+
+	_ = Value{}.String()
+}
+
+func TestValue_Bytes(t *testing.T) {
+	v := String("<value>").Bytes()
+
+	if !bytes.Equal(v, []byte("<value>")) {
+		t.Fatalf("unexpected value: %s", v)
+	}
+}
+
+func TestValue_Bytes_withZeroValue(t *testing.T) {
+	defer func() {
+		p := recover()
+
+		switch e := p.(type) {
+		case error:
+			if e.Error() != "can not represent a zero-value as a byte-slice" {
+				t.Fatalf("expected panic did not occur, got: %s", p)
+			}
+		default:
+			t.Fatal("expected panic did not occur")
+		}
+	}()
+
+	_ = Value{}.Bytes()
 }

--- a/go.sum
+++ b/go.sum
@@ -5,16 +5,10 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
-github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
-github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
-github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=


### PR DESCRIPTION
This PR changes `Value` to fail when attempting to convert a value with no data-source to a string or byte-slice.

Previously, these operations would return empty content instead, whereas if you want to allow for empty values you should be using `Bucket.GetDefault(k, "")` to state so explicitly.

I've also added `Value.Bytes()`, a byte-slice equivalent to `Value.String()`.
