### PR TITLE
Produce a separate log message before each EOL.

### DIFF
--- a/logging/writer.go
+++ b/logging/writer.go
@@ -22,7 +22,6 @@ type writer struct {
 // Each line-feed-terminated line in the data passed to Write() is logged as
 // a separate message. Any unterminated line is buffered until a line-feed is
 // encountered in a future call to Write(), or the writer is closed.
-//
 func NewWriter(l Logger) io.WriteCloser {
 	return &writer{l: l, f: LogString}
 }
@@ -33,7 +32,6 @@ func NewWriter(l Logger) io.WriteCloser {
 // Each line-feed-terminated line in the data passed to Write() is logged as
 // a separate message. Any unterminated line is buffered until a line-feed is
 // encountered in a future call to Write(), or the writer is closed.
-//
 func NewDebugWriter(l Logger) io.WriteCloser {
 	return &writer{l: l, f: DebugString}
 }

--- a/logging/writer.go
+++ b/logging/writer.go
@@ -19,18 +19,10 @@ type writer struct {
 // NewWriter returns an io.WriteCloser that writes content to the given
 // logger.
 //
-// The string passed to Write() is sliced by end-of-line (EOL) characters and
-// each substring in between the EOL characters is written as a separate log
-// message.
+// Each line-feed-terminated line in the data passed to Write() is logged as
+// a separate message. Any unterminated line is buffered until a line-feed is
+// encountered in a future call to Write(), or the writer is closed.
 //
-// If the entire string or its last section does not terminate with an EOL
-// character, it is buffered inside the writer. The writer keeps buffering the
-// string until it detects an EOL character and produces a log message with the
-// buffered string content before the EOL character.
-//
-// When Close() is called the writer checks if there is any remaining buffered
-// string content available and, if there is, the writer flushes the remaining
-// content as a message to the Logger.
 func NewWriter(l Logger) io.WriteCloser {
 	return &writer{l: l, f: LogString}
 }
@@ -38,18 +30,10 @@ func NewWriter(l Logger) io.WriteCloser {
 // NewDebugWriter returns an io.Writer that writes content to the given
 // logger as debug messages.
 //
-// The string passed to Write() is sliced by end-of-line (EOL) characters and
-// each substring in between the EOL characters is written as a separate log
-// message.
+// Each line-feed-terminated line in the data passed to Write() is logged as
+// a separate message. Any unterminated line is buffered until a line-feed is
+// encountered in a future call to Write(), or the writer is closed.
 //
-// If the entire string or its last section does not terminate with an EOL
-// character, it is buffered inside the writer. The writer keeps buffering the
-// string until it detects an EOL character and produces a log message with the
-// buffered string content before the EOL character.
-//
-// When Close() is called the writer checks if there is any remaining buffered
-// string content available and, if there is, the writer flushes the remaining
-// content as a message to the Logger.
 func NewDebugWriter(l Logger) io.WriteCloser {
 	return &writer{l: l, f: DebugString}
 }

--- a/logging/writer.go
+++ b/logging/writer.go
@@ -1,29 +1,70 @@
 package logging
 
-import "io"
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+)
 
 // writer is an implementation of io.Writer that writes to a logger.
 type writer struct {
 	l Logger
 	f func(Logger, string)
+
+	mu  sync.Mutex
+	buf strings.Builder
 }
 
 // NewWriter returns an io.Writer that writes content to the given logger.
 //
-// Each call to Write() produces a separate log message.
+// The string passed to Write() is sliced by end-of-line (EOL) characters and
+// each substring in between the EOL characters is written as a separate log
+// message.
+//
+// If the entire string or its last section does not terminate with an EOL
+// character, it is buffered inside the writer. The writer keeps buffering the
+// string until it detects an EOL character and produces a log message with the
+// buffered string content before the EOL character.
 func NewWriter(l Logger) io.Writer {
-	return &writer{l, LogString}
+	return &writer{l: l, f: LogString}
 }
 
 // NewDebugWriter returns an io.Writer that writes content to the given logger
 // as debug messages.
 //
-// Each call to Write() produces a separate log message.
+// The string passed to Write() is sliced by end-of-line (EOL) characters and
+// each substring in between the EOL characters is written as a separate log
+// message.
+//
+// If the entire string or its last section does not terminate with an EOL
+// character, it is buffered inside the writer. The writer keeps buffering the
+// string until it detects an EOL character and produces a log message with the
+// buffered string content before the EOL character.
 func NewDebugWriter(l Logger) io.Writer {
-	return &writer{l, DebugString}
+	return &writer{l: l, f: DebugString}
 }
 
 func (w *writer) Write(data []byte) (int, error) {
-	w.f(w.l, string(data))
-	return len(data), nil
+	var n int
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	i := bytes.IndexRune(data, '\n')
+	for i != -1 {
+		w.buf.Write(data[:i])
+		w.f(w.l, w.buf.String())
+		n += w.buf.Len()
+		w.buf.Reset()
+
+		data = data[i+1:]
+
+		i = bytes.IndexRune(data, '\n')
+	}
+
+	// Write the remaining data, if any, into the temporary string buffer
+	w.buf.Write(data)
+
+	return n, nil
 }

--- a/logging/writer.go
+++ b/logging/writer.go
@@ -12,11 +12,12 @@ type writer struct {
 	l Logger
 	f func(Logger, string)
 
-	mu  sync.Mutex
+	m   sync.Mutex
 	buf strings.Builder
 }
 
-// NewWriter returns an io.Writer that writes content to the given logger.
+// NewWriter returns an io.WriteCloser that writes content to the given
+// logger.
 //
 // The string passed to Write() is sliced by end-of-line (EOL) characters and
 // each substring in between the EOL characters is written as a separate log
@@ -26,12 +27,16 @@ type writer struct {
 // character, it is buffered inside the writer. The writer keeps buffering the
 // string until it detects an EOL character and produces a log message with the
 // buffered string content before the EOL character.
-func NewWriter(l Logger) io.Writer {
+//
+// When Close() is called the writer checks if there is any remaining buffered
+// string content available and, if there is, the writer flushes the remaining
+// content as a message to the Logger.
+func NewWriter(l Logger) io.WriteCloser {
 	return &writer{l: l, f: LogString}
 }
 
-// NewDebugWriter returns an io.Writer that writes content to the given logger
-// as debug messages.
+// NewDebugWriter returns an io.Writer that writes content to the given
+// logger as debug messages.
 //
 // The string passed to Write() is sliced by end-of-line (EOL) characters and
 // each substring in between the EOL characters is written as a separate log
@@ -41,21 +46,24 @@ func NewWriter(l Logger) io.Writer {
 // character, it is buffered inside the writer. The writer keeps buffering the
 // string until it detects an EOL character and produces a log message with the
 // buffered string content before the EOL character.
-func NewDebugWriter(l Logger) io.Writer {
+//
+// When Close() is called the writer checks if there is any remaining buffered
+// string content available and, if there is, the writer flushes the remaining
+// content as a message to the Logger.
+func NewDebugWriter(l Logger) io.WriteCloser {
 	return &writer{l: l, f: DebugString}
 }
 
 func (w *writer) Write(data []byte) (int, error) {
-	var n int
+	n := len(data)
 
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.m.Lock()
+	defer w.m.Unlock()
 
 	i := bytes.IndexRune(data, '\n')
 	for i != -1 {
 		w.buf.Write(data[:i])
 		w.f(w.l, w.buf.String())
-		n += w.buf.Len()
 		w.buf.Reset()
 
 		data = data[i+1:]
@@ -67,4 +75,16 @@ func (w *writer) Write(data []byte) (int, error) {
 	w.buf.Write(data)
 
 	return n, nil
+}
+
+func (w *writer) Close() error {
+	w.m.Lock()
+	defer w.m.Unlock()
+
+	if w.buf.Len() > 0 {
+		w.f(w.l, w.buf.String())
+		w.buf.Reset()
+	}
+
+	return nil
 }

--- a/logging/writer_test.go
+++ b/logging/writer_test.go
@@ -14,7 +14,7 @@ var _ = Describe("NewWriter", func() {
 		m := []byte("<message1>\n<message2>\n<message3>")
 		n, err := writer.Write(m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(n).To(Equal(20))
+		Expect(n).To(BeNumerically("==", len(m)))
 
 		Expect(logger.Messages()).To(ConsistOf(
 			BufferedLogMessage{
@@ -32,7 +32,7 @@ var _ = Describe("NewWriter", func() {
 		m = []byte("<message4>\n<message5>\n")
 		n, err = writer.Write(m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(n).To(Equal(30))
+		Expect(n).To(BeNumerically("==", len(m)))
 
 		Expect(logger.Messages()).To(ConsistOf(
 			BufferedLogMessage{
@@ -41,6 +41,39 @@ var _ = Describe("NewWriter", func() {
 			},
 			BufferedLogMessage{
 				Message: "<message5>",
+				IsDebug: false,
+			},
+		))
+	})
+
+	It("writes the remaining buffered content when Close() is called", func() {
+		logger := &BufferedLogger{}
+		writer := NewWriter(logger)
+
+		m := []byte("<message1>\n<message2>\n<message3>")
+		n, err := writer.Write(m)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(n).To(BeNumerically("==", len(m)))
+
+		Expect(logger.Messages()).To(ConsistOf(
+			BufferedLogMessage{
+				Message: "<message1>",
+				IsDebug: false,
+			},
+			BufferedLogMessage{
+				Message: "<message2>",
+				IsDebug: false,
+			},
+		))
+
+		logger.Reset()
+
+		err = writer.Close()
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(logger.Messages()).To(ConsistOf(
+			BufferedLogMessage{
+				Message: "<message3>",
 				IsDebug: false,
 			},
 		))
@@ -55,7 +88,7 @@ var _ = Describe("NewDebugWriter", func() {
 		m := []byte("<message1>\n<message2>\n<message3>")
 		n, err := writer.Write(m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(n).To(Equal(20))
+		Expect(n).To(BeNumerically("==", len(m)))
 
 		Expect(logger.Messages()).To(ConsistOf(
 			BufferedLogMessage{
@@ -73,7 +106,7 @@ var _ = Describe("NewDebugWriter", func() {
 		m = []byte("<message4>\n<message5>\n")
 		n, err = writer.Write(m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(n).To(Equal(30))
+		Expect(n).To(BeNumerically("==", len(m)))
 
 		Expect(logger.Messages()).To(ConsistOf(
 			BufferedLogMessage{
@@ -82,6 +115,39 @@ var _ = Describe("NewDebugWriter", func() {
 			},
 			BufferedLogMessage{
 				Message: "<message5>",
+				IsDebug: true,
+			},
+		))
+	})
+
+	It("writes the remaining buffered content when Close() is called", func() {
+		logger := &BufferedLogger{CaptureDebug: true}
+		writer := NewDebugWriter(logger)
+
+		m := []byte("<message1>\n<message2>\n<message3>")
+		n, err := writer.Write(m)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(n).To(BeNumerically("==", len(m)))
+
+		Expect(logger.Messages()).To(ConsistOf(
+			BufferedLogMessage{
+				Message: "<message1>",
+				IsDebug: true,
+			},
+			BufferedLogMessage{
+				Message: "<message2>",
+				IsDebug: true,
+			},
+		))
+
+		logger.Reset()
+
+		err = writer.Close()
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(logger.Messages()).To(ConsistOf(
+			BufferedLogMessage{
+				Message: "<message3>",
 				IsDebug: true,
 			},
 		))

--- a/logging/writer_test.go
+++ b/logging/writer_test.go
@@ -11,14 +11,36 @@ var _ = Describe("NewWriter", func() {
 		logger := &BufferedLogger{}
 		writer := NewWriter(logger)
 
-		m := []byte("<message>")
+		m := []byte("<message1>\n<message2>\n<message3>")
 		n, err := writer.Write(m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(n).To(Equal(len(m)))
+		Expect(n).To(Equal(20))
 
 		Expect(logger.Messages()).To(ConsistOf(
 			BufferedLogMessage{
-				Message: "<message>",
+				Message: "<message1>",
+				IsDebug: false,
+			},
+			BufferedLogMessage{
+				Message: "<message2>",
+				IsDebug: false,
+			},
+		))
+
+		logger.Reset()
+
+		m = []byte("<message4>\n<message5>\n")
+		n, err = writer.Write(m)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(n).To(Equal(30))
+
+		Expect(logger.Messages()).To(ConsistOf(
+			BufferedLogMessage{
+				Message: "<message3><message4>",
+				IsDebug: false,
+			},
+			BufferedLogMessage{
+				Message: "<message5>",
 				IsDebug: false,
 			},
 		))
@@ -30,14 +52,36 @@ var _ = Describe("NewDebugWriter", func() {
 		logger := &BufferedLogger{CaptureDebug: true}
 		writer := NewDebugWriter(logger)
 
-		m := []byte("<message>")
+		m := []byte("<message1>\n<message2>\n<message3>")
 		n, err := writer.Write(m)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(n).To(Equal(len(m)))
+		Expect(n).To(Equal(20))
 
 		Expect(logger.Messages()).To(ConsistOf(
 			BufferedLogMessage{
-				Message: "<message>",
+				Message: "<message1>",
+				IsDebug: true,
+			},
+			BufferedLogMessage{
+				Message: "<message2>",
+				IsDebug: true,
+			},
+		))
+
+		logger.Reset()
+
+		m = []byte("<message4>\n<message5>\n")
+		n, err = writer.Write(m)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(n).To(Equal(30))
+
+		Expect(logger.Messages()).To(ConsistOf(
+			BufferedLogMessage{
+				Message: "<message3><message4>",
+				IsDebug: true,
+			},
+			BufferedLogMessage{
+				Message: "<message5>",
 				IsDebug: true,
 			},
 		))


### PR DESCRIPTION
This PR changes the behaviour of `logging.writer` to produce a
separate log message before each end-of-line (EOL) is encountered in the
string.

The writer also internally buffers any strings not terminated with an EOL
character until the next call to `Write()` will have string with an EOL character in it.
Then the entire buffered content before an EOL character is produced into a
separate log message.