### PR TITLE
Implement `Promoter` and `Demoter`.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -22,15 +22,12 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
-github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/logging/demoter.go
+++ b/logging/demoter.go
@@ -1,0 +1,61 @@
+package logging
+
+// Demoter is an implementation of Logger that forwards all messages to a
+// target logger as debug messages. Thus, it "demotes" non-debug messages to
+// the debug level.
+type Demoter struct {
+	// Target is the logger to which messages are forwarded.
+	Target Logger
+}
+
+// Log writes an application log message formatted according to a format
+// specifier.
+//
+// It should be used for messages that are intended for people responsible
+// for operating the application, such as the end-user or operations staff.
+//
+// fmt is the format specifier, as per fmt.Printf(), etc.
+func (l *Demoter) Log(fmt string, v ...interface{}) {
+	l.Debug(fmt, v...)
+}
+
+// LogString writes a pre-formatted application log message.
+//
+// It should be used for messages that are intended for people responsible
+// for operating the application, such as the end-user or operations staff.
+func (l *Demoter) LogString(s string) {
+	l.DebugString(s)
+}
+
+// Debug writes a debug log message formatted according to a format
+// specifier.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software
+// developers that maintain the application.
+//
+// fmt is the format specifier, as per fmt.Printf(), etc.
+func (l *Demoter) Debug(fmt string, v ...interface{}) {
+	Debug(l.Target, fmt, v...)
+}
+
+// DebugString writes a pre-formatted debug log message.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software
+// developers that maintain the application.
+func (l *Demoter) DebugString(s string) {
+	DebugString(l.Target, s)
+}
+
+// IsDebug returns true if this logger will perform debug logging.
+//
+// Generally the application should just call Debug() or DebugString()
+// without calling IsDebug(), however it can be used to check if debug
+// logging is necessary before executing expensive code that is only used to
+// obtain debug information.
+func (l *Demoter) IsDebug() bool {
+	return l.Target.IsDebug()
+}

--- a/logging/demoter_test.go
+++ b/logging/demoter_test.go
@@ -6,68 +6,74 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("type Promoter", func() {
+var _ = Describe("type Demoter", func() {
 	var (
 		target *BufferedLogger
-		logger *Promoter
+		logger *Demoter
 	)
 
 	BeforeEach(func() {
-		target = &BufferedLogger{}
+		target = &BufferedLogger{
+			CaptureDebug: true,
+		}
 
-		logger = &Promoter{
+		logger = &Demoter{
 			Target: target,
 		}
 	})
 
 	Describe("func Log()", func() {
-		It("forwards to the target", func() {
+		It("forwards a debug message to the target", func() {
 			logger.Log("message <%s>", "arg")
 
 			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
 				Message: "message <arg>",
-				IsDebug: false,
+				IsDebug: true,
 			}))
 		})
 	})
 
 	Describe("func LogString()", func() {
-		It("forwards to the target", func() {
+		It("forwards a debug message to the target", func() {
 			logger.LogString("<message>")
 
 			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
 				Message: "<message>",
-				IsDebug: false,
+				IsDebug: true,
 			}))
 		})
 	})
 
 	Describe("func Debug()", func() {
-		It("forwards a non-debug message to the target", func() {
+		It("forwards to the target", func() {
 			logger.Debug("message <%s>", "arg")
 
 			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
 				Message: "message <arg>",
-				IsDebug: false,
+				IsDebug: true,
 			}))
 		})
 	})
 
 	Describe("func DebugString()", func() {
-		It("forwards a non-debug message to the target", func() {
+		It("forwards to the target", func() {
 			logger.DebugString("<message>")
 
 			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
 				Message: "<message>",
-				IsDebug: false,
+				IsDebug: true,
 			}))
 		})
 	})
 
 	Describe("func IsDebug()", func() {
-		It("returns true even if the target does not capture debug messages", func() {
-			target.CaptureDebug = false
+		It("returns true if the target captures debug messages", func() {
 			Expect(logger.IsDebug()).To(BeTrue())
+		})
+
+		It("returns false if the target does not capture debug messages", func() {
+			target.CaptureDebug = false
+			Expect(logger.IsDebug()).To(BeFalse())
 		})
 	})
 })

--- a/logging/promoter.go
+++ b/logging/promoter.go
@@ -1,8 +1,10 @@
 package logging
 
-// Promoter is an implementation of Logger that forwards all messages to
-// a target logger as NON-DEBUG messages.
+// Promoter is an implementation of Logger that forwards all messages to a
+// target logger as non-debug messages. Thus, it "promotes" debug messages to
+// the non-debug level.
 type Promoter struct {
+	// Target is the logger to which messages are forwarded.
 	Target Logger
 }
 

--- a/logging/promoter.go
+++ b/logging/promoter.go
@@ -1,0 +1,59 @@
+package logging
+
+// Promoter is an implementation of Logger that forwards all messages to
+// a target logger as NON-DEBUG messages.
+type Promoter struct {
+	Target Logger
+}
+
+// Log writes an application log message formatted according to a format
+// specifier.
+//
+// It should be used for messages that are intended for people responsible
+// for operating the application, such as the end-user or operations staff.
+//
+// fmt is the format specifier, as per fmt.Printf(), etc.
+func (l *Promoter) Log(fmt string, v ...interface{}) {
+	Log(l.Target, fmt, v...)
+}
+
+// LogString writes a pre-formatted application log message.
+//
+// It should be used for messages that are intended for people responsible
+// for operating the application, such as the end-user or operations staff.
+func (l *Promoter) LogString(s string) {
+	LogString(l.Target, s)
+}
+
+// Debug writes a debug log message formatted according to a format
+// specifier.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software
+// developers that maintain the application.
+//
+// fmt is the format specifier, as per fmt.Printf(), etc.
+func (l *Promoter) Debug(fmt string, v ...interface{}) {
+	l.Log(fmt, v...)
+}
+
+// DebugString writes a pre-formatted debug log message.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software
+// developers that maintain the application.
+func (l *Promoter) DebugString(s string) {
+	l.LogString(s)
+}
+
+// IsDebug returns true if this logger will perform debug logging.
+//
+// Generally the application should just call Debug() or DebugString()
+// without calling IsDebug(), however it can be used to check if debug
+// logging is necessary before executing expensive code that is only used to
+// obtain debug information.
+func (l *Promoter) IsDebug() bool {
+	return true
+}

--- a/logging/promoter_test.go
+++ b/logging/promoter_test.go
@@ -1,0 +1,73 @@
+package logging_test
+
+import (
+	. "github.com/dogmatiq/dodeca/logging"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Promoter", func() {
+	var (
+		target   *BufferedLogger
+		promoter *Promoter
+	)
+
+	BeforeEach(func() {
+		target = &BufferedLogger{}
+
+		promoter = &Promoter{
+			Target: target,
+		}
+	})
+
+	Describe("func Log()", func() {
+		It("forwards to the target", func() {
+			promoter.Log("message <%s>", "arg")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "message <arg>",
+				IsDebug: false,
+			}))
+		})
+	})
+
+	Describe("func LogString()", func() {
+		It("forwards to the target", func() {
+			promoter.LogString("<message>")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "<message>",
+				IsDebug: false,
+			}))
+		})
+	})
+
+	Describe("func Debug()", func() {
+		It("forwards a non-debug message to the target", func() {
+			promoter.Debug("message <%s>", "arg")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "message <arg>",
+				IsDebug: false,
+			}))
+		})
+	})
+
+	Describe("func DebugString()", func() {
+		It("forwards a non-debug message to the target", func() {
+			promoter.DebugString("<message>")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "<message>",
+				IsDebug: false,
+			}))
+		})
+	})
+
+	Describe("func IsDebug()", func() {
+		It("returns true even if the target does not capture debug messages", func() {
+			target.CaptureDebug = false
+			Expect(promoter.IsDebug()).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
Fixes #16 

This PR introduces two new `Logger` implementations: `Promoter` and `Demoter`.

`Promoter` takes a target logger and forwards all log messages as **non-debug** messages, in this sense it "promotes" debug messages to non-debug.

`Demoter` is the opposite. It forwards all log messages as **debug** messages, thus "demoting" non-debug messages to debug level.