### PR TITLE
Add `Prefix()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- Add `Promote()`, which returns logger that promotes all messages to non-debug level
-- Add `Demote()`, which returns logger that demotes all messages to debug level
-- Add `Wrapper` and `Unwrap()`
+- Add `Prefix()`, which returns a logger that prepends a static prefix to all messages
+- Add `Promote()`, which returns a logger that promotes all messages to non-debug level
+- Add `Demote()`, which returns a logger that demotes all messages to debug level
+- Add `Wrapper` and `Unwrap()` for inspecting loggers that wrap other loggers
 
 ## [0.2.1] - 2020-03-08
 

--- a/logging/prefix.go
+++ b/logging/prefix.go
@@ -1,0 +1,110 @@
+package logging
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Prefix returns a logger that prefixes all messages with a fixed string.
+//
+// f is the format specifier for the prefix, as per fmt.Printf(), etc.
+//
+// If the target is nil, DefaultLogger is used.
+func Prefix(target Logger, f string, v ...interface{}) Logger {
+	p := fmt.Sprintf(f, v...)
+
+	return prefixer{
+		target,
+		p,
+		strings.ReplaceAll(p, "%", "%%"),
+	}
+}
+
+// prefixer is an implementation of Logger that prefixes all message with a
+// fixed string.
+type prefixer struct {
+	// Target is the logger to which messages are forwarded.
+	Target Logger
+
+	// StringPrefix is the string to prefix to all messages.
+	StringPrefix string
+
+	// FormatSpecifierPrefix is the prefix string escaped for use as a format
+	// specifier.
+	FormatSpecifierPrefix string
+}
+
+// Log writes an application log message formatted according to a format
+// specifier.
+//
+// It should be used for messages that are intended for people responsible for
+// operating the application, such as the end-user or operations staff.
+//
+// f is the format specifier, as per fmt.Printf(), etc.
+func (l prefixer) Log(f string, v ...interface{}) {
+	Log(
+		l.Target,
+		l.FormatSpecifierPrefix+f,
+		v...,
+	)
+}
+
+// LogString writes a pre-formatted application log message.
+//
+// It should be used for messages that are intended for people responsible for
+// operating the application, such as the end-user or operations staff.
+func (l prefixer) LogString(s string) {
+	LogString(
+		l.Target,
+		l.StringPrefix+s,
+	)
+}
+
+// Debug writes a debug log message formatted according to a format specifier.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software developers
+// that maintain the application.
+//
+// f is the format specifier, as per fmt.Printf(), etc.
+func (l prefixer) Debug(f string, v ...interface{}) {
+	Debug(
+		l.Target,
+		l.FormatSpecifierPrefix+f,
+		v...,
+	)
+}
+
+// DebugString writes a pre-formatted debug log message.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software developers
+// that maintain the application.
+func (l prefixer) DebugString(s string) {
+	DebugString(
+		l.Target,
+		l.StringPrefix+s,
+	)
+}
+
+// IsDebug returns true if this logger will perform debug logging.
+//
+// Generally the application should just call Debug() or DebugString() without
+// calling IsDebug(), however it can be used to check if debug logging is
+// necessary before executing expensive code that is only used to obtain debug
+// information.
+func (l prefixer) IsDebug() bool {
+	return IsDebug(l.Target)
+}
+
+// UnwrapLogger returns the logger wrapped by this logger.
+//
+// If ok is true it means that this logger is wrapping another logger, even
+// if that logger is nil, indicating that DefaultLogger should be used.
+//
+// If ok is false it means that this logger is not wrapping another logger.
+func (l prefixer) UnwrapLogger() (Logger, bool) {
+	return l.Target, true
+}

--- a/logging/prefix_test.go
+++ b/logging/prefix_test.go
@@ -1,0 +1,84 @@
+package logging_test
+
+import (
+	. "github.com/dogmatiq/dodeca/logging"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func Prefix()", func() {
+	var (
+		target *BufferedLogger
+		logger Logger
+	)
+
+	BeforeEach(func() {
+		target = &BufferedLogger{
+			CaptureDebug: true,
+		}
+
+		logger = Prefix(target, "%s %% ", "<prefix>")
+	})
+
+	Describe("func Log()", func() {
+		It("forwards to the target with the prefix", func() {
+			logger.Log("message <%s>", "arg")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "<prefix> % message <arg>",
+				IsDebug: false,
+			}))
+		})
+	})
+
+	Describe("func LogString()", func() {
+		It("forwards to the target with the prefix", func() {
+			logger.LogString("<message>")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "<prefix> % <message>",
+				IsDebug: false,
+			}))
+		})
+	})
+
+	Describe("func Debug()", func() {
+		It("forwards to the target with the prefix", func() {
+			logger.Debug("message <%s>", "arg")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "<prefix> % message <arg>",
+				IsDebug: true,
+			}))
+		})
+	})
+
+	Describe("func DebugString()", func() {
+		It("fforwards to the target with the prefix", func() {
+			logger.DebugString("<message>")
+
+			Expect(target.Messages()).To(ConsistOf(BufferedLogMessage{
+				Message: "<prefix> % <message>",
+				IsDebug: true,
+			}))
+		})
+	})
+
+	Describe("func IsDebug()", func() {
+		It("returns true if the target captures debug messages", func() {
+			Expect(logger.IsDebug()).To(BeTrue())
+		})
+
+		It("returns false if the target does not capture debug messages", func() {
+			target.CaptureDebug = false
+			Expect(logger.IsDebug()).To(BeFalse())
+		})
+	})
+
+	Describe("func UnwrapLogger()", func() {
+		It("returns the target", func() {
+			l := Unwrap(logger)
+			Expect(l).To(BeIdenticalTo(target))
+		})
+	})
+})


### PR DESCRIPTION
This PR adds the `Prefix()` function, which returns a logger the prepends a static to prefix to every message before forwarding to another logger.

Fixes #17.