### PR TITLE
Add `GetBoolXXX()` functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `Map`, an in-memory implementation of `Bucket`
+- Add `GetBoolXXX()` functions for reading boolean configuration values
 
 ## [0.2.2] - 2020-09-04
 

--- a/config/bool.go
+++ b/config/bool.go
@@ -67,8 +67,8 @@ func GetBoolF(b Bucket, k string) (bool, error) {
 	return GetBoolDefault(b, k, false)
 }
 
-// GetBoolDefault returns boolean representation of the value associated with k,
-// or the default value v if k is undefined.
+// GetBoolDefault returns the boolean representation of the value associated
+// with k, or the default value v if k is undefined.
 //
 // If the value is "true", "yes" or "on", it returns true.
 //
@@ -132,7 +132,7 @@ func MustGetBoolF(b Bucket, k string) bool {
 	return MustGetBoolDefault(b, k, false)
 }
 
-// MustGetBoolDefault returns boolean representation of the value associated
+// MustGetBoolDefault returns the boolean representation of the value associated
 // with k, or the default value v if k is undefined.
 //
 // If the value is "true", "yes" or "on", it returns true.

--- a/config/bool.go
+++ b/config/bool.go
@@ -5,92 +5,144 @@ import (
 	"strings"
 )
 
-// GetBoolT returns the value associated with the given key as a boolean.
+// GetBool returns the boolean representation of the value associated with k.
 //
-// If the value is "true", "yes", or "on", it returns true. If the value is
-// "false", "no", or "off", it returns false. These string comparisons are
-// case-insensitive. It returns an error if any other value is used.
+// If the value is "true", "yes" or "on", v and ok are both true.
 //
-// If they key is not defined, it returns true.
-func GetBoolT(b Bucket, k string) (bool, error) {
-	return GetBoolDefault(b, k, true)
-}
-
-// GetBoolF returns the value associated with the given key as a boolean.
+// If the value is "false", "no" or "off", v is false and ok is true.
 //
-// If the value is "true", "yes", or "on", it returns true. If the value is
-// "false", "no", or "off", it returns false. These string comparisons are
-// case-insensitive. It returns an error if any other value is used.
+// If k is undefined, ok is false and err is nil.
 //
-// If they key is not defined, it returns false.
-func GetBoolF(b Bucket, k string) (bool, error) {
-	return GetBoolDefault(b, k, false)
-}
-
-// GetBoolDefault returns the value associated with the given key as a
-// boolean.
-//
-// If the value is "true", "yes", or "on", it returns true. If the value is
-// "false", "no", or "off", it returns false. These string comparisons are
-// case-insensitive. It returns an error if any other value is used.
-//
-// If they key is not defined, it returns v.
-func GetBoolDefault(b Bucket, k string, v bool) (bool, error) {
+// If k is defined but its value is not listed above, err is a non-nil error
+// describing the invalid value.
+func GetBool(b Bucket, k string) (v bool, ok bool, err error) {
 	x := b.Get(k)
 
 	if x.IsZero() {
-		return v, nil
+		return false, false, nil
 	}
 
 	s, err := x.AsString()
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	switch strings.ToLower(s) {
 	case "true", "yes", "on":
-		return true, nil
+		return true, true, nil
 	case "false", "no", "off":
-		return false, nil
+		return false, true, nil
 	default:
-		return false, fmt.Errorf("%s is not a valid boolean value: %s", k, s)
+		return false, false, fmt.Errorf(
+			`%s is not a boolean, got %#v, expected "true", "false", "yes", "no", "on" or "off"`,
+			k,
+			s,
+		)
 	}
 }
 
-// MustGetBoolT returns the value associated with the given key as a boolean.
+// GetBoolT returns the boolean representation of the value associated with k,
+// or true if k is undefined.
 //
-// If the value is "true", "yes", or "on", it returns true. If the value is
-// "false", "no", or "off", it returns false. These string comparisons are
-// case-insensitive. It panics if any other value is used.
+// If the value is "true", "yes" or "on", it returns true.
 //
-// If they key is not defined, it returns true.
+// If the value is "false", "no" or "off", it returns false.
+//
+// If k is defined but its value is not listed above, it returns an error
+// describing the invalid value.
+func GetBoolT(b Bucket, k string) (bool, error) {
+	return GetBoolDefault(b, k, true)
+}
+
+// GetBoolF returns the boolean representation of the value associated with k,
+// or false if k is undefined.
+//
+// If the value is "true", "yes" or "on", it returns true.
+//
+// If the value is "false", "no" or "off", it returns false.
+//
+// If k is defined but its value is not listed above, it returns an error
+// describing the invalid value.
+func GetBoolF(b Bucket, k string) (bool, error) {
+	return GetBoolDefault(b, k, false)
+}
+
+// GetBoolDefault returns boolean representation of the value associated with k,
+// or the default value v if k is undefined.
+//
+// If the value is "true", "yes" or "on", it returns true.
+//
+// If the value is "false", "no" or "off", it returns false.
+//
+// If k is defined but its value is not listed above, it returns an error
+// describing the invalid value.
+func GetBoolDefault(b Bucket, k string, v bool) (bool, error) {
+	x, ok, err := GetBool(b, k)
+	if err != nil {
+		return false, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetBool returns the boolean representation of the value associated with
+// k or panics if unable to do so.
+//
+// If the value is "true", "yes" or "on", v and ok are both true.
+//
+// If the value is "false", "no" or "off", v is false and ok is true.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value is not listed above.
+func MustGetBool(b Bucket, k string) (v bool, ok bool) {
+	v, ok, err := GetBool(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetBoolT returns the boolean representation of the value associated with
+// k, or true if k is undefined.
+//
+// If the value is "true", "yes" or "on", it returns true.
+//
+// If the value is "false", "no" or "off", it returns false.
+//
+// It panics if k is defined but its value is not listed above.
 func MustGetBoolT(b Bucket, k string) bool {
 	return MustGetBoolDefault(b, k, true)
 }
 
-// MustGetBoolF returns the value associated with the given key as a boolean.
+// MustGetBoolF returns the boolean representation of the value associated with
+// k, or false if k is undefined.
 //
-// If the value is "true", "yes", or "on", it returns true. If the value is
-// "false", "no", or "off", it returns false. These string comparisons are
-// case-insensitive. It panics if any other value is used.
+// If the value is "true", "yes" or "on", it returns true.
 //
-// If they key is not defined, it returns false.
+// If the value is "false", "no" or "off", it returns false.
+//
+// It panics if k is defined but its value is not listed above.
 func MustGetBoolF(b Bucket, k string) bool {
 	return MustGetBoolDefault(b, k, false)
 }
 
-// MustGetBoolDefault returns the value associated with the given key as a
-// boolean.
+// MustGetBoolDefault returns boolean representation of the value associated
+// with k, or the default value v if k is undefined.
 //
-// If the value is "true", "yes", or "on", it returns true. If the value is
-// "false", "no", or "off", it returns false. These string comparisons are
-// case-insensitive. It panics if any other value is used.
+// If the value is "true", "yes" or "on", it returns true.
 //
-// If they key is not defined, it returns v.
+// If the value is "false", "no" or "off", it returns false.
+//
+// It panics if k is defined but its value is not listed above.
 func MustGetBoolDefault(b Bucket, k string, v bool) bool {
-	v, err := GetBoolDefault(b, k, v)
-	if err != nil {
-		panic(err)
+	if x, ok := MustGetBool(b, k); ok {
+		return x
 	}
 
 	return v

--- a/config/bool.go
+++ b/config/bool.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetBoolT returns the value associated with the given key as a boolean.
+//
+// If the value is "true", "yes", or "on", it returns true. If the value is
+// "false", "no", or "off", it returns false. These string comparisons are
+// case-insensitive. It returns an error if any other value is used.
+//
+// If they key is not defined, it returns true.
+func GetBoolT(b Bucket, k string) (bool, error) {
+	return GetBoolDefault(b, k, true)
+}
+
+// GetBoolF returns the value associated with the given key as a boolean.
+//
+// If the value is "true", "yes", or "on", it returns true. If the value is
+// "false", "no", or "off", it returns false. These string comparisons are
+// case-insensitive. It returns an error if any other value is used.
+//
+// If they key is not defined, it returns false.
+func GetBoolF(b Bucket, k string) (bool, error) {
+	return GetBoolDefault(b, k, false)
+}
+
+// GetBoolDefault returns the value associated with the given key as a
+// boolean.
+//
+// If the value is "true", "yes", or "on", it returns true. If the value is
+// "false", "no", or "off", it returns false. These string comparisons are
+// case-insensitive. It returns an error if any other value is used.
+//
+// If they key is not defined, it returns v.
+func GetBoolDefault(b Bucket, k string, v bool) (bool, error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return v, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return false, err
+	}
+
+	switch strings.ToLower(s) {
+	case "true", "yes", "on":
+		return true, nil
+	case "false", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("%s is not a valid boolean value: %s", k, s)
+	}
+}
+
+// MustGetBoolT returns the value associated with the given key as a boolean.
+//
+// If the value is "true", "yes", or "on", it returns true. If the value is
+// "false", "no", or "off", it returns false. These string comparisons are
+// case-insensitive. It panics if any other value is used.
+//
+// If they key is not defined, it returns true.
+func MustGetBoolT(b Bucket, k string) bool {
+	return MustGetBoolDefault(b, k, true)
+}
+
+// MustGetBoolF returns the value associated with the given key as a boolean.
+//
+// If the value is "true", "yes", or "on", it returns true. If the value is
+// "false", "no", or "off", it returns false. These string comparisons are
+// case-insensitive. It panics if any other value is used.
+//
+// If they key is not defined, it returns false.
+func MustGetBoolF(b Bucket, k string) bool {
+	return MustGetBoolDefault(b, k, false)
+}
+
+// MustGetBoolDefault returns the value associated with the given key as a
+// boolean.
+//
+// If the value is "true", "yes", or "on", it returns true. If the value is
+// "false", "no", or "off", it returns false. These string comparisons are
+// case-insensitive. It panics if any other value is used.
+//
+// If they key is not defined, it returns v.
+func MustGetBoolDefault(b Bucket, k string, v bool) bool {
+	v, err := GetBoolDefault(b, k, v)
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}

--- a/config/bool_test.go
+++ b/config/bool_test.go
@@ -3,10 +3,101 @@ package config_test
 import (
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
+
+var boolTableEntries = []TableEntry{
+	Entry("truthy: true", "true", true),
+	Entry("truthy: yes", "yes", true),
+	Entry("truthy: on", "on", true),
+
+	Entry("falsey: false", "false", false),
+	Entry("falsey: no", "no", false),
+	Entry("falsey: off", "off", false),
+}
+
+var _ = Describe("func GetBool()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
+
+			v, ok, err := GetBool(b, "<key>")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal(expect))
+			Expect(ok).To(BeTrue())
+		},
+		boolTableEntries...,
+	)
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetBool(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetBool(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`))
+	})
+})
+
+func ExampleGetBool() {
+	os.Setenv("FOO", "true")
+
+	v, ok, err := config.GetBool(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+var _ = Describe("func GetBoolT()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
+
+			v, err := GetBoolT(b, "<key>")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal(expect))
+		},
+		boolTableEntries...,
+	)
+
+	It("returns true if the value is not defined", func() {
+		b := Map{}
+
+		v, err := GetBoolT(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeTrue())
+	})
+
+	It("returns an error if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetBoolT(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`))
+	})
+})
 
 func ExampleGetBoolT() {
 	os.Setenv("FOO", "false")
@@ -25,22 +116,34 @@ func ExampleGetBoolT() {
 	// Output: false!
 }
 
-func ExampleGetBoolT_withUndefinedVariable() {
-	os.Setenv("FOO", "")
+var _ = Describe("func GetBoolF()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
 
-	v, err := config.GetBoolT(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
+			v, err := GetBoolF(b, "<key>")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal(expect))
+		},
+		boolTableEntries...,
+	)
 
-	if v {
-		fmt.Println("true!")
-	} else {
-		fmt.Println("false!")
-	}
+	It("returns false if the value is not defined", func() {
+		b := Map{}
 
-	// Output: true!
-}
+		v, err := GetBoolF(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeFalse())
+	})
+
+	It("returns an error if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetBoolF(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`))
+	})
+})
 
 func ExampleGetBoolF() {
 	os.Setenv("FOO", "true")
@@ -59,22 +162,34 @@ func ExampleGetBoolF() {
 	// Output: true!
 }
 
-func ExampleGetBoolF_withUndefinedVariable() {
-	os.Setenv("FOO", "")
+var _ = Describe("func GetBoolDefault()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
 
-	v, err := config.GetBoolF(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
+			v, err := GetBoolDefault(b, "<key>", true)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(v).To(Equal(expect))
+		},
+		boolTableEntries...,
+	)
 
-	if v {
-		fmt.Println("true!")
-	} else {
-		fmt.Println("false!")
-	}
+	It("returns the default value if the value is not defined", func() {
+		b := Map{}
 
-	// Output: false!
-}
+		v, err := GetBoolDefault(b, "<key>", true)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeTrue())
+	})
+
+	It("returns an error if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetBoolDefault(b, "<key>", true)
+		Expect(err).To(MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`))
+	})
+})
 
 func ExampleGetBoolDefault() {
 	os.Setenv("FOO", "false")
@@ -93,32 +208,82 @@ func ExampleGetBoolDefault() {
 	// Output: false!
 }
 
-func ExampleGetBoolDefault_withUndefinedVariable() {
-	os.Setenv("FOO", "")
+var _ = Describe("func MustGetBool()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
 
-	v, err := config.GetBoolDefault(config.Environment(), "FOO", true)
-	if err != nil {
-		panic(err)
-	}
+			v, ok := MustGetBool(b, "<key>")
+			Expect(v).To(Equal(expect))
+			Expect(ok).To(BeTrue())
+		},
+		boolTableEntries...,
+	)
 
-	if v {
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetBool(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetBool(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`),
+		))
+	})
+})
+
+func ExampleMustGetBool() {
+	os.Setenv("FOO", "false")
+
+	v, ok := config.MustGetBool(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else if v {
 		fmt.Println("true!")
 	} else {
 		fmt.Println("false!")
 	}
 
-	// Output: true!
+	// Output: false!
 }
 
-func TestGetBoolDefault_withInvalidValue(t *testing.T) {
-	os.Setenv("FOO", "<invalid>")
+var _ = Describe("func MustGetBoolT()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
 
-	_, err := config.GetBoolDefault(config.Environment(), "FOO", true)
+			v := MustGetBoolT(b, "<key>")
+			Expect(v).To(Equal(expect))
+		},
+		boolTableEntries...,
+	)
 
-	if err == nil || err.Error() != "FOO is not a valid boolean value: <invalid>" {
-		t.Fatal("unexpected error, got:", err)
-	}
-}
+	It("returns true if the value is not defined", func() {
+		b := Map{}
+
+		v := MustGetBoolT(b, "<key>")
+		Expect(v).To(BeTrue())
+	})
+
+	It("panics if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetBoolT(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`),
+		))
+	})
+})
 
 func ExampleMustGetBoolT() {
 	os.Setenv("FOO", "false")
@@ -132,17 +297,35 @@ func ExampleMustGetBoolT() {
 	// Output: false!
 }
 
-func ExampleMustGetBoolT_withUndefinedVariable() {
-	os.Setenv("FOO", "")
+var _ = Describe("func MustGetBoolF()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
 
-	if config.MustGetBoolT(config.Environment(), "FOO") {
-		fmt.Println("true!")
-	} else {
-		fmt.Println("false!")
-	}
+			v := MustGetBoolF(b, "<key>")
+			Expect(v).To(Equal(expect))
+		},
+		boolTableEntries...,
+	)
 
-	// Output: true!
-}
+	It("returns false if the value is not defined", func() {
+		b := Map{}
+
+		v := MustGetBoolF(b, "<key>")
+		Expect(v).To(BeFalse())
+	})
+
+	It("panics if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetBoolF(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`),
+		))
+	})
+})
 
 func ExampleMustGetBoolF() {
 	os.Setenv("FOO", "true")
@@ -156,17 +339,35 @@ func ExampleMustGetBoolF() {
 	// Output: true!
 }
 
-func ExampleMustGetBoolF_withUndefinedVariable() {
-	os.Setenv("FOO", "")
+var _ = Describe("func MustGetBoolDefault()", func() {
+	DescribeTable(
+		"it returns the expected value",
+		func(str string, expect bool) {
+			b := Map{"<key>": String(str)}
 
-	if config.MustGetBoolF(config.Environment(), "FOO") {
-		fmt.Println("true!")
-	} else {
-		fmt.Println("false!")
-	}
+			v := MustGetBoolDefault(b, "<key>", true)
+			Expect(v).To(Equal(expect))
+		},
+		boolTableEntries...,
+	)
 
-	// Output: false!
-}
+	It("returns the default value if the value is not defined", func() {
+		b := Map{}
+
+		v := MustGetBoolDefault(b, "<key>", true)
+		Expect(v).To(BeTrue())
+	})
+
+	It("panics if the value is not one of the accepted values", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetBoolDefault(b, "<key>", true)
+		}).To(PanicWith(
+			MatchError(`<key> is not a boolean, got "<invalid>", expected "true", "false", "yes", "no", "on" or "off"`),
+		))
+	})
+})
 
 func ExampleMustGetBoolDefault() {
 	os.Setenv("FOO", "false")
@@ -178,35 +379,4 @@ func ExampleMustGetBoolDefault() {
 	}
 
 	// Output: false!
-}
-
-func ExampleMustGetBoolDefault_withUndefinedVariable() {
-	os.Setenv("FOO", "")
-
-	if config.MustGetBoolDefault(config.Environment(), "FOO", true) {
-		fmt.Println("true!")
-	} else {
-		fmt.Println("false!")
-	}
-
-	// Output: true!
-}
-
-func TestMustGetBoolDefault_withInvalidValue(t *testing.T) {
-	defer func() {
-		r := recover()
-
-		err, ok := r.(error)
-		if !ok {
-			panic(r)
-		}
-
-		if err.Error() != "FOO is not a valid boolean value: <invalid>" {
-			t.Fatal("unexpected error, got:", err)
-		}
-	}()
-
-	os.Setenv("FOO", "<invalid>")
-
-	config.MustGetBoolDefault(config.Environment(), "FOO", true)
 }

--- a/config/bool_test.go
+++ b/config/bool_test.go
@@ -83,7 +83,7 @@ var _ = Describe("func GetBoolT()", func() {
 		boolTableEntries...,
 	)
 
-	It("returns true if the value is not defined", func() {
+	It("returns true if the key is not defined", func() {
 		b := Map{}
 
 		v, err := GetBoolT(b, "<key>")
@@ -129,7 +129,7 @@ var _ = Describe("func GetBoolF()", func() {
 		boolTableEntries...,
 	)
 
-	It("returns false if the value is not defined", func() {
+	It("returns false if the key is not defined", func() {
 		b := Map{}
 
 		v, err := GetBoolF(b, "<key>")
@@ -175,7 +175,7 @@ var _ = Describe("func GetBoolDefault()", func() {
 		boolTableEntries...,
 	)
 
-	It("returns the default value if the value is not defined", func() {
+	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
 		v, err := GetBoolDefault(b, "<key>", true)
@@ -267,7 +267,7 @@ var _ = Describe("func MustGetBoolT()", func() {
 		boolTableEntries...,
 	)
 
-	It("returns true if the value is not defined", func() {
+	It("returns true if the key is not defined", func() {
 		b := Map{}
 
 		v := MustGetBoolT(b, "<key>")
@@ -309,7 +309,7 @@ var _ = Describe("func MustGetBoolF()", func() {
 		boolTableEntries...,
 	)
 
-	It("returns false if the value is not defined", func() {
+	It("returns false if the key is not defined", func() {
 		b := Map{}
 
 		v := MustGetBoolF(b, "<key>")
@@ -351,7 +351,7 @@ var _ = Describe("func MustGetBoolDefault()", func() {
 		boolTableEntries...,
 	)
 
-	It("returns the default value if the value is not defined", func() {
+	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
 		v := MustGetBoolDefault(b, "<key>", true)

--- a/config/bool_test.go
+++ b/config/bool_test.go
@@ -1,0 +1,212 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dogmatiq/dodeca/config"
+)
+
+func ExampleGetBoolT() {
+	os.Setenv("FOO", "false")
+
+	v, err := config.GetBoolT(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: false!
+}
+
+func ExampleGetBoolT_withUndefinedVariable() {
+	os.Setenv("FOO", "")
+
+	v, err := config.GetBoolT(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+func ExampleGetBoolF() {
+	os.Setenv("FOO", "true")
+
+	v, err := config.GetBoolF(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+func ExampleGetBoolF_withUndefinedVariable() {
+	os.Setenv("FOO", "")
+
+	v, err := config.GetBoolF(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: false!
+}
+
+func ExampleGetBoolDefault() {
+	os.Setenv("FOO", "false")
+
+	v, err := config.GetBoolDefault(config.Environment(), "FOO", true)
+	if err != nil {
+		panic(err)
+	}
+
+	if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: false!
+}
+
+func ExampleGetBoolDefault_withUndefinedVariable() {
+	os.Setenv("FOO", "")
+
+	v, err := config.GetBoolDefault(config.Environment(), "FOO", true)
+	if err != nil {
+		panic(err)
+	}
+
+	if v {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+func TestGetBoolDefault_withInvalidValue(t *testing.T) {
+	os.Setenv("FOO", "<invalid>")
+
+	_, err := config.GetBoolDefault(config.Environment(), "FOO", true)
+
+	if err == nil || err.Error() != "FOO is not a valid boolean value: <invalid>" {
+		t.Fatal("unexpected error, got:", err)
+	}
+}
+
+func ExampleMustGetBoolT() {
+	os.Setenv("FOO", "false")
+
+	if config.MustGetBoolT(config.Environment(), "FOO") {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: false!
+}
+
+func ExampleMustGetBoolT_withUndefinedVariable() {
+	os.Setenv("FOO", "")
+
+	if config.MustGetBoolT(config.Environment(), "FOO") {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+func ExampleMustGetBoolF() {
+	os.Setenv("FOO", "true")
+
+	if config.MustGetBoolF(config.Environment(), "FOO") {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+func ExampleMustGetBoolF_withUndefinedVariable() {
+	os.Setenv("FOO", "")
+
+	if config.MustGetBoolF(config.Environment(), "FOO") {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: false!
+}
+
+func ExampleMustGetBoolDefault() {
+	os.Setenv("FOO", "false")
+
+	if config.MustGetBoolDefault(config.Environment(), "FOO", true) {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: false!
+}
+
+func ExampleMustGetBoolDefault_withUndefinedVariable() {
+	os.Setenv("FOO", "")
+
+	if config.MustGetBoolDefault(config.Environment(), "FOO", true) {
+		fmt.Println("true!")
+	} else {
+		fmt.Println("false!")
+	}
+
+	// Output: true!
+}
+
+func TestMustGetBoolDefault_withInvalidValue(t *testing.T) {
+	defer func() {
+		r := recover()
+
+		err, ok := r.(error)
+		if !ok {
+			panic(r)
+		}
+
+		if err.Error() != "FOO is not a valid boolean value: <invalid>" {
+			t.Fatal("unexpected error, got:", err)
+		}
+	}()
+
+	os.Setenv("FOO", "<invalid>")
+
+	config.MustGetBoolDefault(config.Environment(), "FOO", true)
+}


### PR DESCRIPTION
Partially addresses #33 

This PR adds several new helper functions for reading configuration values from a `config.Bucket` and parsing them as a boolean.

