### PR TITLE
Add `config.Map` type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `Map`, an in-memory implementation of `Bucket`
+
 ## [0.2.2] - 2020-09-04
 
 ### Added

--- a/config/bucket.go
+++ b/config/bucket.go
@@ -24,3 +24,42 @@ type Bucket interface {
 	// returns false.
 	Each(fn EachFunc) bool
 }
+
+// Map is an in-memory implementation of Bucket.
+type Map map[string]Value
+
+// Get returns the value associated with the given key.
+//
+// If they key is not defined, it returns a zero-value.
+func (m Map) Get(k string) Value {
+	return m[k]
+}
+
+// GetDefault returns the value associated with the given key.
+//
+// If the key is not defined, it returns a value with the content of v.
+func (m Map) GetDefault(k string, v string) Value {
+	x := m.Get(k)
+
+	if x.IsZero() {
+		return String(v)
+	}
+
+	return x
+}
+
+// Each calls fn for each key/value pair in the bucket.
+//
+// If fn returns false, iteration is stopped.
+//
+// Each returns true if iteration completes fully, or false if fn()
+// returns false.
+func (m Map) Each(fn EachFunc) bool {
+	for k, v := range m {
+		if !fn(k, v) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/config/bucket_test.go
+++ b/config/bucket_test.go
@@ -22,6 +22,11 @@ var _ = Describe("type Map", func() {
 			v := bucket.Get("<key-1>")
 			Expect(v).To(Equal(String("<value-1>")))
 		})
+
+		It("returns the zero-value if the key is undefined", func() {
+			v := bucket.Get("<undefined>")
+			Expect(v.IsZero()).To(BeTrue())
+		})
 	})
 
 	Describe("func GetDefault()", func() {

--- a/config/bucket_test.go
+++ b/config/bucket_test.go
@@ -1,0 +1,69 @@
+package config_test
+
+import (
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Map", func() {
+	var bucket Map
+
+	BeforeEach(func() {
+		bucket = Map{
+			"<key-1>": String("<value-1>"),
+			"<key-2>": String("<value-2>"),
+			"<key-3>": Value{},
+		}
+	})
+
+	Describe("func Get()", func() {
+		It("returns the value associated with the key", func() {
+			v := bucket.Get("<key-1>")
+			Expect(v).To(Equal(String("<value-1>")))
+		})
+	})
+
+	Describe("func GetDefault()", func() {
+		It("returns the value associated with the key", func() {
+			v := bucket.GetDefault("<key-1>", "<default>")
+			Expect(v).To(Equal(String("<value-1>")))
+		})
+
+		It("returns the default value if the key is undefined", func() {
+			v := bucket.GetDefault("<undefined>", "<default>")
+			Expect(v).To(Equal(String("<default>")))
+		})
+
+		It("returns the default value if the value is the zero-value", func() {
+			v := bucket.GetDefault("<key-3>", "<default>")
+			Expect(v).To(Equal(String("<default>")))
+		})
+	})
+
+	Describe("func Each()", func() {
+		It("invokes the function for each key/value pair", func() {
+			calls := map[string]Value{}
+
+			fn := func(k string, v Value) bool {
+				calls[k] = v
+				return true
+			}
+
+			Expect(bucket.Each(fn)).To(BeTrue())
+			Expect(calls).To(BeEquivalentTo(bucket))
+		})
+
+		It("stops iterating if the function returns false", func() {
+			count := 0
+
+			fn := func(k string, v Value) bool {
+				count++
+				return false
+			}
+
+			Expect(bucket.Each(fn)).To(BeFalse())
+			Expect(count).To(Equal(1))
+		})
+	})
+})

--- a/config/environment.go
+++ b/config/environment.go
@@ -39,6 +39,8 @@ func GetEnv(k string) string {
 	return s
 }
 
+// environment is an implementation of Bucket that sources values from
+// environment variables.
 type environment struct{}
 
 // Get returns the value associated with the given key.

--- a/config/ginkgo_test.go
+++ b/config/ginkgo_test.go
@@ -1,0 +1,15 @@
+package config_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
-github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=


### PR DESCRIPTION
This PR adds a new implementation of `config.Bucket` based on a Go map.

The only existing implementation is the one returned by `Environment()` which queries environment variables directly.