### PR TITLE
Add `GetInt()` and its variants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Add `Map`, an in-memory implementation of `Bucket`
-- Add `GetBoolXXX()` functions for reading boolean configuration values
+- Add `GetBool()` and its variants for reading `bool` configuration values
+- Add `GetInt64()` and its variants for reading `int64` configuration values
 
 ## [0.2.2] - 2020-09-04
 

--- a/config/int.go
+++ b/config/int.go
@@ -34,3 +34,17 @@ func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
 
 	return v, true, nil
 }
+
+// MustGetInt64 returns the int64 representation of the value associated with k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an int64.
+func MustGetInt64(b Bucket, k string) (v int64, ok bool) {
+	v, ok, err := GetInt64(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}

--- a/config/int.go
+++ b/config/int.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetInt returns the int representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an int, err is a
+// non-nil error describing the invalid value.
+func GetInt(b Bucket, k string) (v int, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseInt(s, 10, 0)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid signed integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return int(v64), true, nil
+}
+
+// GetIntDefault returns the int representation of the value associated with
+// k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an int, it returns an
+// error describing the invalid value.
+func GetIntDefault(b Bucket, k string, v int) (int, error) {
+	x, ok, err := GetInt(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetInt returns the int representation of the value associated with k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an int.
+func MustGetInt(b Bucket, k string) (v int, ok bool) {
+	v, ok, err := GetInt(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetIntDefault returns the int representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an int.
+func MustGetIntDefault(b Bucket, k string, v int) int {
+	if x, ok := MustGetInt(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/int.go
+++ b/config/int.go
@@ -9,15 +9,15 @@ import (
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an int, err is a non-nil
+// error describing the invalid value.
 func GetInt(b Bucket, k string) (v int, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 0)
 	return int(v64), ok, err
 }
 
-// GetIntDefault returns the int representation of the value associated with
-// k, or the default value v if k is undefined.
+// GetIntDefault returns the int representation of the value associated with k,
+// or the default value v if k is undefined.
 //
 // If k is defined but its value can not be parsed as an int, it returns an
 // error describing the invalid value.
@@ -48,8 +48,8 @@ func MustGetInt(b Bucket, k string) (v int, ok bool) {
 	return v, ok
 }
 
-// MustGetIntDefault returns the int representation of the value associated
-// with k, or the default value v if k is undefined.
+// MustGetIntDefault returns the int representation of the value associated with
+// k, or the default value v if k is undefined.
 //
 // It panics if k is defined but its value can not be parsed as an int.
 func MustGetIntDefault(b Bucket, k string, v int) int {

--- a/config/int.go
+++ b/config/int.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetInt64 returns the int64 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an int64, err is a
+// non-nil error describing the invalid value.
+func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v, err = strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid signed 64-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return v, true, nil
+}

--- a/config/int.go
+++ b/config/int.go
@@ -9,7 +9,7 @@ import (
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int, err is a non-nil
+// If k is defined but its value cannot be parsed as an int, err is a non-nil
 // error describing the invalid value.
 func GetInt(b Bucket, k string) (v int, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 0)
@@ -19,7 +19,7 @@ func GetInt(b Bucket, k string) (v int, ok bool, err error) {
 // GetIntDefault returns the int representation of the value associated with k,
 // or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an int, it returns an
+// If k is defined but its value cannot be parsed as an int, it returns an
 // error describing the invalid value.
 func GetIntDefault(b Bucket, k string, v int) (int, error) {
 	x, ok, err := GetInt(b, k)
@@ -38,7 +38,7 @@ func GetIntDefault(b Bucket, k string, v int) (int, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an int.
+// It panics if k is defined but its value cannot be parsed as an int.
 func MustGetInt(b Bucket, k string) (v int, ok bool) {
 	v, ok, err := GetInt(b, k)
 	if err != nil {
@@ -51,7 +51,7 @@ func MustGetInt(b Bucket, k string) (v int, ok bool) {
 // MustGetIntDefault returns the int representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an int.
+// It panics if k is defined but its value cannot be parsed as an int.
 func MustGetIntDefault(b Bucket, k string, v int) int {
 	if x, ok := MustGetInt(b, k); ok {
 		return x

--- a/config/int.go
+++ b/config/int.go
@@ -35,6 +35,24 @@ func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
 	return v, true, nil
 }
 
+// GetInt64Default returns the int64 representation of the value associated with
+// k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an int64, it returns an
+// error describing the invalid value.
+func GetInt64Default(b Bucket, k string, v int64) (int64, error) {
+	x, ok, err := GetInt64(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
 // MustGetInt64 returns the int64 representation of the value associated with k.
 //
 // If k is undefined, ok is false.

--- a/config/int16.go
+++ b/config/int16.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int16, err is a non-nil
+// If k is defined but its value cannot be parsed as an int16, err is a non-nil
 // error describing the invalid value.
 func GetInt16(b Bucket, k string) (v int16, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 16)
@@ -14,7 +14,7 @@ func GetInt16(b Bucket, k string) (v int16, ok bool, err error) {
 // GetInt16Default returns the int16 representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an int16, it returns an
+// If k is defined but its value cannot be parsed as an int16, it returns an
 // error describing the invalid value.
 func GetInt16Default(b Bucket, k string, v int16) (int16, error) {
 	x, ok, err := GetInt16(b, k)
@@ -33,7 +33,7 @@ func GetInt16Default(b Bucket, k string, v int16) (int16, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an int16.
+// It panics if k is defined but its value cannot be parsed as an int16.
 func MustGetInt16(b Bucket, k string) (v int16, ok bool) {
 	v, ok, err := GetInt16(b, k)
 	if err != nil {
@@ -46,7 +46,7 @@ func MustGetInt16(b Bucket, k string) (v int16, ok bool) {
 // MustGetInt16Default returns the int16 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an int16.
+// It panics if k is defined but its value cannot be parsed as an int16.
 func MustGetInt16Default(b Bucket, k string, v int16) int16 {
 	if x, ok := MustGetInt16(b, k); ok {
 		return x

--- a/config/int16.go
+++ b/config/int16.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetInt16 returns the int16 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an int16, err is a
 // non-nil error describing the invalid value.
 func GetInt16(b Bucket, k string) (v int16, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v64, err := strconv.ParseInt(s, 10, 16)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid signed 16-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return int16(v64), true, nil
+	v64, ok, err := getInt(b, k, 16)
+	return int16(v64), ok, err
 }
 
 // GetInt16Default returns the int16 representation of the value associated with

--- a/config/int16.go
+++ b/config/int16.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetInt16 returns the int16 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an int16, err is a
+// non-nil error describing the invalid value.
+func GetInt16(b Bucket, k string) (v int16, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseInt(s, 10, 16)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid signed 16-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return int16(v64), true, nil
+}
+
+// GetInt16Default returns the int16 representation of the value associated with
+// k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an int16, it returns an
+// error describing the invalid value.
+func GetInt16Default(b Bucket, k string, v int16) (int16, error) {
+	x, ok, err := GetInt16(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetInt16 returns the int16 representation of the value associated with k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an int16.
+func MustGetInt16(b Bucket, k string) (v int16, ok bool) {
+	v, ok, err := GetInt16(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetInt16Default returns the int16 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an int16.
+func MustGetInt16Default(b Bucket, k string, v int16) int16 {
+	if x, ok := MustGetInt16(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/int16.go
+++ b/config/int16.go
@@ -4,8 +4,8 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int16, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an int16, err is a non-nil
+// error describing the invalid value.
 func GetInt16(b Bucket, k string) (v int16, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 16)
 	return int16(v64), ok, err

--- a/config/int16_test.go
+++ b/config/int16_test.go
@@ -1,0 +1,169 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetInt16()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetInt16(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetInt16(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetInt16(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt16() {
+	os.Setenv("FOO", "123")
+
+	v, ok, err := config.GetInt16(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func GetInt16Default()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetInt16Default(b, "<key>", 456)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetInt16Default(b, "<key>", 456)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(456))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetInt16Default(b, "<key>", 456)
+		Expect(err).To(MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt16Default() {
+	os.Setenv("FOO", "123")
+
+	v, err := config.GetInt16Default(config.Environment(), "FOO", 456)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetInt16()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetInt16(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetInt16(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt16(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt16() {
+	os.Setenv("FOO", "123")
+
+	v, ok := config.MustGetInt16(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetInt16Default()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetInt16Default(b, "<key>", 456)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetInt16Default(b, "<key>", 456)
+		Expect(v).To(BeEquivalentTo(456))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt16Default(b, "<key>", 456)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt16Default() {
+	os.Setenv("FOO", "123")
+
+	v := config.MustGetInt16Default(config.Environment(), "FOO", 456)
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}

--- a/config/int16_test.go
+++ b/config/int16_test.go
@@ -33,7 +33,7 @@ var _ = Describe("func GetInt16()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetInt16(b, "<key>")
@@ -66,7 +66,7 @@ var _ = Describe("func GetInt16Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetInt16Default(b, "<key>", -10)
@@ -98,7 +98,7 @@ var _ = Describe("func MustGetInt16()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -131,7 +131,7 @@ var _ = Describe("func MustGetInt16Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/int16_test.go
+++ b/config/int16_test.go
@@ -117,6 +117,14 @@ var _ = Describe("func MustGetInt16()", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt16(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
@@ -155,6 +163,13 @@ var _ = Describe("func MustGetInt16Default()", func() {
 
 		v := MustGetInt16Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v := MustGetInt16Default(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {

--- a/config/int16_test.go
+++ b/config/int16_test.go
@@ -11,12 +11,21 @@ import (
 )
 
 var _ = Describe("func GetInt16()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok, err := GetInt16(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok, err := GetInt16(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 		Expect(ok).To(BeTrue())
 	})
 
@@ -54,12 +63,20 @@ func ExampleGetInt16() {
 }
 
 var _ = Describe("func GetInt16Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, err := GetInt16Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, err := GetInt16Default(b, "<key>", -10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {
@@ -92,7 +109,7 @@ func ExampleGetInt16Default() {
 }
 
 var _ = Describe("func MustGetInt16()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok := MustGetInt16(b, "<key>")
@@ -133,7 +150,7 @@ func ExampleMustGetInt16() {
 }
 
 var _ = Describe("func MustGetInt16Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v := MustGetInt16Default(b, "<key>", -10)

--- a/config/int16_test.go
+++ b/config/int16_test.go
@@ -1,10 +1,6 @@
 package config_test
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/dogmatiq/dodeca/config"
 	. "github.com/dogmatiq/dodeca/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,23 +41,6 @@ var _ = Describe("func GetInt16()", func() {
 	})
 })
 
-func ExampleGetInt16() {
-	os.Setenv("FOO", "123")
-
-	v, ok, err := config.GetInt16(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func GetInt16Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -94,19 +73,6 @@ var _ = Describe("func GetInt16Default()", func() {
 		Expect(err).To(MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
-
-func ExampleGetInt16Default() {
-	os.Setenv("FOO", "123")
-
-	v, err := config.GetInt16Default(config.Environment(), "FOO", -10)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}
 
 var _ = Describe("func MustGetInt16()", func() {
 	It("returns a positive integer value", func() {
@@ -143,20 +109,6 @@ var _ = Describe("func MustGetInt16()", func() {
 	})
 })
 
-func ExampleMustGetInt16() {
-	os.Setenv("FOO", "123")
-
-	v, ok := config.MustGetInt16(config.Environment(), "FOO")
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func MustGetInt16Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -189,13 +141,3 @@ var _ = Describe("func MustGetInt16Default()", func() {
 		))
 	})
 })
-
-func ExampleMustGetInt16Default() {
-	os.Setenv("FOO", "123")
-
-	v := config.MustGetInt16Default(config.Environment(), "FOO", -10)
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}

--- a/config/int16_test.go
+++ b/config/int16_test.go
@@ -57,7 +57,7 @@ var _ = Describe("func GetInt16Default()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v, err := GetInt16Default(b, "<key>", 456)
+		v, err := GetInt16Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
 	})
@@ -65,15 +65,15 @@ var _ = Describe("func GetInt16Default()", func() {
 	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
-		v, err := GetInt16Default(b, "<key>", 456)
+		v, err := GetInt16Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(v).To(BeEquivalentTo(456))
+		Expect(v).To(BeEquivalentTo(-10))
 	})
 
 	It("returns an error if the value can not be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
-		_, err := GetInt16Default(b, "<key>", 456)
+		_, err := GetInt16Default(b, "<key>", -10)
 		Expect(err).To(MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
@@ -81,7 +81,7 @@ var _ = Describe("func GetInt16Default()", func() {
 func ExampleGetInt16Default() {
 	os.Setenv("FOO", "123")
 
-	v, err := config.GetInt16Default(config.Environment(), "FOO", 456)
+	v, err := config.GetInt16Default(config.Environment(), "FOO", -10)
 	if err != nil {
 		panic(err)
 	}
@@ -136,22 +136,22 @@ var _ = Describe("func MustGetInt16Default()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v := MustGetInt16Default(b, "<key>", 456)
+		v := MustGetInt16Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
 	})
 
 	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
-		v := MustGetInt16Default(b, "<key>", 456)
-		Expect(v).To(BeEquivalentTo(456))
+		v := MustGetInt16Default(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-10))
 	})
 
 	It("panics if the value can not be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
-			MustGetInt16Default(b, "<key>", 456)
+			MustGetInt16Default(b, "<key>", -10)
 		}).To(PanicWith(
 			MatchError(`<key> is not a valid signed 16-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
 		))
@@ -161,7 +161,7 @@ var _ = Describe("func MustGetInt16Default()", func() {
 func ExampleMustGetInt16Default() {
 	os.Setenv("FOO", "123")
 
-	v := config.MustGetInt16Default(config.Environment(), "FOO", 456)
+	v := config.MustGetInt16Default(config.Environment(), "FOO", -10)
 
 	fmt.Printf("the value is %d!\n", v)
 

--- a/config/int32.go
+++ b/config/int32.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetInt32 returns the int32 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an int32, err is a
+// non-nil error describing the invalid value.
+func GetInt32(b Bucket, k string) (v int32, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid signed 32-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return int32(v64), true, nil
+}
+
+// GetInt32Default returns the int32 representation of the value associated with
+// k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an int32, it returns an
+// error describing the invalid value.
+func GetInt32Default(b Bucket, k string, v int32) (int32, error) {
+	x, ok, err := GetInt32(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetInt32 returns the int32 representation of the value associated with k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an int32.
+func MustGetInt32(b Bucket, k string) (v int32, ok bool) {
+	v, ok, err := GetInt32(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetInt32Default returns the int32 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an int32.
+func MustGetInt32Default(b Bucket, k string, v int32) int32 {
+	if x, ok := MustGetInt32(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/int32.go
+++ b/config/int32.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int32, err is a non-nil
+// If k is defined but its value cannot be parsed as an int32, err is a non-nil
 // error describing the invalid value.
 func GetInt32(b Bucket, k string) (v int32, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 32)
@@ -14,7 +14,7 @@ func GetInt32(b Bucket, k string) (v int32, ok bool, err error) {
 // GetInt32Default returns the int32 representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an int32, it returns an
+// If k is defined but its value cannot be parsed as an int32, it returns an
 // error describing the invalid value.
 func GetInt32Default(b Bucket, k string, v int32) (int32, error) {
 	x, ok, err := GetInt32(b, k)
@@ -33,7 +33,7 @@ func GetInt32Default(b Bucket, k string, v int32) (int32, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an int32.
+// It panics if k is defined but its value cannot be parsed as an int32.
 func MustGetInt32(b Bucket, k string) (v int32, ok bool) {
 	v, ok, err := GetInt32(b, k)
 	if err != nil {
@@ -46,7 +46,7 @@ func MustGetInt32(b Bucket, k string) (v int32, ok bool) {
 // MustGetInt32Default returns the int32 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an int32.
+// It panics if k is defined but its value cannot be parsed as an int32.
 func MustGetInt32Default(b Bucket, k string, v int32) int32 {
 	if x, ok := MustGetInt32(b, k); ok {
 		return x

--- a/config/int32.go
+++ b/config/int32.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetInt32 returns the int32 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an int32, err is a
 // non-nil error describing the invalid value.
 func GetInt32(b Bucket, k string) (v int32, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v64, err := strconv.ParseInt(s, 10, 32)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid signed 32-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return int32(v64), true, nil
+	v64, ok, err := getInt(b, k, 32)
+	return int32(v64), ok, err
 }
 
 // GetInt32Default returns the int32 representation of the value associated with

--- a/config/int32.go
+++ b/config/int32.go
@@ -4,8 +4,8 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int32, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an int32, err is a non-nil
+// error describing the invalid value.
 func GetInt32(b Bucket, k string) (v int32, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 32)
 	return int32(v64), ok, err

--- a/config/int32_test.go
+++ b/config/int32_test.go
@@ -57,7 +57,7 @@ var _ = Describe("func GetInt32Default()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v, err := GetInt32Default(b, "<key>", 456)
+		v, err := GetInt32Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
 	})
@@ -65,15 +65,15 @@ var _ = Describe("func GetInt32Default()", func() {
 	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
-		v, err := GetInt32Default(b, "<key>", 456)
+		v, err := GetInt32Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(v).To(BeEquivalentTo(456))
+		Expect(v).To(BeEquivalentTo(-10))
 	})
 
 	It("returns an error if the value can not be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
-		_, err := GetInt32Default(b, "<key>", 456)
+		_, err := GetInt32Default(b, "<key>", -10)
 		Expect(err).To(MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
@@ -81,7 +81,7 @@ var _ = Describe("func GetInt32Default()", func() {
 func ExampleGetInt32Default() {
 	os.Setenv("FOO", "123")
 
-	v, err := config.GetInt32Default(config.Environment(), "FOO", 456)
+	v, err := config.GetInt32Default(config.Environment(), "FOO", -10)
 	if err != nil {
 		panic(err)
 	}
@@ -136,22 +136,22 @@ var _ = Describe("func MustGetInt32Default()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v := MustGetInt32Default(b, "<key>", 456)
+		v := MustGetInt32Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
 	})
 
 	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
-		v := MustGetInt32Default(b, "<key>", 456)
-		Expect(v).To(BeEquivalentTo(456))
+		v := MustGetInt32Default(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-10))
 	})
 
 	It("panics if the value can not be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
-			MustGetInt32Default(b, "<key>", 456)
+			MustGetInt32Default(b, "<key>", -10)
 		}).To(PanicWith(
 			MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
 		))
@@ -161,7 +161,7 @@ var _ = Describe("func MustGetInt32Default()", func() {
 func ExampleMustGetInt32Default() {
 	os.Setenv("FOO", "123")
 
-	v := config.MustGetInt32Default(config.Environment(), "FOO", 456)
+	v := config.MustGetInt32Default(config.Environment(), "FOO", -10)
 
 	fmt.Printf("the value is %d!\n", v)
 

--- a/config/int32_test.go
+++ b/config/int32_test.go
@@ -1,10 +1,6 @@
 package config_test
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/dogmatiq/dodeca/config"
 	. "github.com/dogmatiq/dodeca/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,23 +41,6 @@ var _ = Describe("func GetInt32()", func() {
 	})
 })
 
-func ExampleGetInt32() {
-	os.Setenv("FOO", "123")
-
-	v, ok, err := config.GetInt32(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func GetInt32Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -94,19 +73,6 @@ var _ = Describe("func GetInt32Default()", func() {
 		Expect(err).To(MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
-
-func ExampleGetInt32Default() {
-	os.Setenv("FOO", "123")
-
-	v, err := config.GetInt32Default(config.Environment(), "FOO", -10)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}
 
 var _ = Describe("func MustGetInt32()", func() {
 	It("returns a positive integer value", func() {
@@ -143,20 +109,6 @@ var _ = Describe("func MustGetInt32()", func() {
 	})
 })
 
-func ExampleMustGetInt32() {
-	os.Setenv("FOO", "123")
-
-	v, ok := config.MustGetInt32(config.Environment(), "FOO")
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func MustGetInt32Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -189,13 +141,3 @@ var _ = Describe("func MustGetInt32Default()", func() {
 		))
 	})
 })
-
-func ExampleMustGetInt32Default() {
-	os.Setenv("FOO", "123")
-
-	v := config.MustGetInt32Default(config.Environment(), "FOO", -10)
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}

--- a/config/int32_test.go
+++ b/config/int32_test.go
@@ -117,6 +117,14 @@ var _ = Describe("func MustGetInt32()", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt32(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
@@ -155,6 +163,13 @@ var _ = Describe("func MustGetInt32Default()", func() {
 
 		v := MustGetInt32Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v := MustGetInt32Default(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {

--- a/config/int32_test.go
+++ b/config/int32_test.go
@@ -33,7 +33,7 @@ var _ = Describe("func GetInt32()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetInt32(b, "<key>")
@@ -66,7 +66,7 @@ var _ = Describe("func GetInt32Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetInt32Default(b, "<key>", -10)
@@ -98,7 +98,7 @@ var _ = Describe("func MustGetInt32()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -131,7 +131,7 @@ var _ = Describe("func MustGetInt32Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/int32_test.go
+++ b/config/int32_test.go
@@ -1,0 +1,169 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetInt32()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetInt32(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetInt32(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetInt32(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt32() {
+	os.Setenv("FOO", "123")
+
+	v, ok, err := config.GetInt32(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func GetInt32Default()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetInt32Default(b, "<key>", 456)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetInt32Default(b, "<key>", 456)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(456))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetInt32Default(b, "<key>", 456)
+		Expect(err).To(MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt32Default() {
+	os.Setenv("FOO", "123")
+
+	v, err := config.GetInt32Default(config.Environment(), "FOO", 456)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetInt32()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetInt32(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetInt32(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt32(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt32() {
+	os.Setenv("FOO", "123")
+
+	v, ok := config.MustGetInt32(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetInt32Default()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetInt32Default(b, "<key>", 456)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetInt32Default(b, "<key>", 456)
+		Expect(v).To(BeEquivalentTo(456))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt32Default(b, "<key>", 456)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed 32-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt32Default() {
+	os.Setenv("FOO", "123")
+
+	v := config.MustGetInt32Default(config.Environment(), "FOO", 456)
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}

--- a/config/int32_test.go
+++ b/config/int32_test.go
@@ -11,12 +11,21 @@ import (
 )
 
 var _ = Describe("func GetInt32()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok, err := GetInt32(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok, err := GetInt32(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 		Expect(ok).To(BeTrue())
 	})
 
@@ -54,12 +63,20 @@ func ExampleGetInt32() {
 }
 
 var _ = Describe("func GetInt32Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, err := GetInt32Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, err := GetInt32Default(b, "<key>", -10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {
@@ -92,7 +109,7 @@ func ExampleGetInt32Default() {
 }
 
 var _ = Describe("func MustGetInt32()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok := MustGetInt32(b, "<key>")
@@ -133,7 +150,7 @@ func ExampleMustGetInt32() {
 }
 
 var _ = Describe("func MustGetInt32Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v := MustGetInt32Default(b, "<key>", -10)

--- a/config/int64.go
+++ b/config/int64.go
@@ -4,8 +4,8 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int64, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an int64, err is a non-nil
+// error describing the invalid value.
 func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
 	return getInt(b, k, 64)
 }

--- a/config/int64.go
+++ b/config/int64.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int64, err is a non-nil
+// If k is defined but its value cannot be parsed as an int64, err is a non-nil
 // error describing the invalid value.
 func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
 	return getInt(b, k, 64)
@@ -13,7 +13,7 @@ func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
 // GetInt64Default returns the int64 representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an int64, it returns an
+// If k is defined but its value cannot be parsed as an int64, it returns an
 // error describing the invalid value.
 func GetInt64Default(b Bucket, k string, v int64) (int64, error) {
 	x, ok, err := GetInt64(b, k)
@@ -32,7 +32,7 @@ func GetInt64Default(b Bucket, k string, v int64) (int64, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an int64.
+// It panics if k is defined but its value cannot be parsed as an int64.
 func MustGetInt64(b Bucket, k string) (v int64, ok bool) {
 	v, ok, err := GetInt64(b, k)
 	if err != nil {
@@ -45,7 +45,7 @@ func MustGetInt64(b Bucket, k string) (v int64, ok bool) {
 // MustGetInt64Default returns the int64 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an int64.
+// It panics if k is defined but its value cannot be parsed as an int64.
 func MustGetInt64Default(b Bucket, k string, v int64) int64 {
 	if x, ok := MustGetInt64(b, k); ok {
 		return x

--- a/config/int64.go
+++ b/config/int64.go
@@ -66,3 +66,15 @@ func MustGetInt64(b Bucket, k string) (v int64, ok bool) {
 
 	return v, ok
 }
+
+// MustGetInt64Default returns the int64 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an int64.
+func MustGetInt64Default(b Bucket, k string, v int64) int64 {
+	if x, ok := MustGetInt64(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/int64.go
+++ b/config/int64.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetInt64 returns the int64 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,7 @@ import (
 // If k is defined but its value can not be parsed as an int64, err is a
 // non-nil error describing the invalid value.
 func GetInt64(b Bucket, k string) (v int64, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v, err = strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid signed 64-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return v, true, nil
+	return getInt(b, k, 64)
 }
 
 // GetInt64Default returns the int64 representation of the value associated with

--- a/config/int64_test.go
+++ b/config/int64_test.go
@@ -117,6 +117,14 @@ var _ = Describe("func MustGetInt64()", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt64(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
@@ -155,6 +163,13 @@ var _ = Describe("func MustGetInt64Default()", func() {
 
 		v := MustGetInt64Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v := MustGetInt64Default(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {

--- a/config/int64_test.go
+++ b/config/int64_test.go
@@ -11,12 +11,21 @@ import (
 )
 
 var _ = Describe("func GetInt64()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok, err := GetInt64(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok, err := GetInt64(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 		Expect(ok).To(BeTrue())
 	})
 
@@ -54,12 +63,20 @@ func ExampleGetInt64() {
 }
 
 var _ = Describe("func GetInt64Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, err := GetInt64Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, err := GetInt64Default(b, "<key>", -10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {
@@ -92,7 +109,7 @@ func ExampleGetInt64Default() {
 }
 
 var _ = Describe("func MustGetInt64()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok := MustGetInt64(b, "<key>")
@@ -133,7 +150,7 @@ func ExampleMustGetInt64() {
 }
 
 var _ = Describe("func MustGetInt64Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v := MustGetInt64Default(b, "<key>", -10)

--- a/config/int64_test.go
+++ b/config/int64_test.go
@@ -1,10 +1,6 @@
 package config_test
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/dogmatiq/dodeca/config"
 	. "github.com/dogmatiq/dodeca/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,23 +41,6 @@ var _ = Describe("func GetInt64()", func() {
 	})
 })
 
-func ExampleGetInt64() {
-	os.Setenv("FOO", "123")
-
-	v, ok, err := config.GetInt64(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func GetInt64Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -94,19 +73,6 @@ var _ = Describe("func GetInt64Default()", func() {
 		Expect(err).To(MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
-
-func ExampleGetInt64Default() {
-	os.Setenv("FOO", "123")
-
-	v, err := config.GetInt64Default(config.Environment(), "FOO", -10)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}
 
 var _ = Describe("func MustGetInt64()", func() {
 	It("returns a positive integer value", func() {
@@ -143,20 +109,6 @@ var _ = Describe("func MustGetInt64()", func() {
 	})
 })
 
-func ExampleMustGetInt64() {
-	os.Setenv("FOO", "123")
-
-	v, ok := config.MustGetInt64(config.Environment(), "FOO")
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func MustGetInt64Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -189,13 +141,3 @@ var _ = Describe("func MustGetInt64Default()", func() {
 		))
 	})
 })
-
-func ExampleMustGetInt64Default() {
-	os.Setenv("FOO", "123")
-
-	v := config.MustGetInt64Default(config.Environment(), "FOO", -10)
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}

--- a/config/int64_test.go
+++ b/config/int64_test.go
@@ -131,3 +131,39 @@ func ExampleMustGetInt64() {
 
 	// Output: the value is 123!
 }
+
+var _ = Describe("func MustGetInt64Default()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetInt64Default(b, "<key>", 456)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetInt64Default(b, "<key>", 456)
+		Expect(v).To(BeEquivalentTo(456))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt64Default(b, "<key>", 456)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt64Default() {
+	os.Setenv("FOO", "123")
+
+	v := config.MustGetInt64Default(config.Environment(), "FOO", 456)
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}

--- a/config/int64_test.go
+++ b/config/int64_test.go
@@ -33,7 +33,7 @@ var _ = Describe("func GetInt64()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetInt64(b, "<key>")
@@ -66,7 +66,7 @@ var _ = Describe("func GetInt64Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetInt64Default(b, "<key>", -10)
@@ -98,7 +98,7 @@ var _ = Describe("func MustGetInt64()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -131,7 +131,7 @@ var _ = Describe("func MustGetInt64Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/int8.go
+++ b/config/int8.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetInt8 returns the int8 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an int8, err is a
+// non-nil error describing the invalid value.
+func GetInt8(b Bucket, k string) (v int8, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseInt(s, 10, 8)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid signed 8-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return int8(v64), true, nil
+}
+
+// GetInt8Default returns the int8 representation of the value associated with
+// k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an int8, it returns an
+// error describing the invalid value.
+func GetInt8Default(b Bucket, k string, v int8) (int8, error) {
+	x, ok, err := GetInt8(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetInt8 returns the int8 representation of the value associated with k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an int8.
+func MustGetInt8(b Bucket, k string) (v int8, ok bool) {
+	v, ok, err := GetInt8(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetInt8Default returns the int8 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an int8.
+func MustGetInt8Default(b Bucket, k string, v int8) int8 {
+	if x, ok := MustGetInt8(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/int8.go
+++ b/config/int8.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetInt8 returns the int8 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an int8, err is a
 // non-nil error describing the invalid value.
 func GetInt8(b Bucket, k string) (v int8, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v64, err := strconv.ParseInt(s, 10, 8)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid signed 8-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return int8(v64), true, nil
+	v64, ok, err := getInt(b, k, 8)
+	return int8(v64), ok, err
 }
 
 // GetInt8Default returns the int8 representation of the value associated with

--- a/config/int8.go
+++ b/config/int8.go
@@ -4,8 +4,8 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int8, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an int8, err is a non-nil
+// error describing the invalid value.
 func GetInt8(b Bucket, k string) (v int8, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 8)
 	return int8(v64), ok, err

--- a/config/int8.go
+++ b/config/int8.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an int8, err is a non-nil
+// If k is defined but its value cannot be parsed as an int8, err is a non-nil
 // error describing the invalid value.
 func GetInt8(b Bucket, k string) (v int8, ok bool, err error) {
 	v64, ok, err := getInt(b, k, 8)
@@ -14,7 +14,7 @@ func GetInt8(b Bucket, k string) (v int8, ok bool, err error) {
 // GetInt8Default returns the int8 representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an int8, it returns an
+// If k is defined but its value cannot be parsed as an int8, it returns an
 // error describing the invalid value.
 func GetInt8Default(b Bucket, k string, v int8) (int8, error) {
 	x, ok, err := GetInt8(b, k)
@@ -33,7 +33,7 @@ func GetInt8Default(b Bucket, k string, v int8) (int8, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an int8.
+// It panics if k is defined but its value cannot be parsed as an int8.
 func MustGetInt8(b Bucket, k string) (v int8, ok bool) {
 	v, ok, err := GetInt8(b, k)
 	if err != nil {
@@ -46,7 +46,7 @@ func MustGetInt8(b Bucket, k string) (v int8, ok bool) {
 // MustGetInt8Default returns the int8 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an int8.
+// It panics if k is defined but its value cannot be parsed as an int8.
 func MustGetInt8Default(b Bucket, k string, v int8) int8 {
 	if x, ok := MustGetInt8(b, k); ok {
 		return x

--- a/config/int8_test.go
+++ b/config/int8_test.go
@@ -11,12 +11,21 @@ import (
 )
 
 var _ = Describe("func GetInt8()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok, err := GetInt8(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok, err := GetInt8(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
 		Expect(ok).To(BeTrue())
 	})
 
@@ -54,12 +63,20 @@ func ExampleGetInt8() {
 }
 
 var _ = Describe("func GetInt8Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, err := GetInt8Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt8(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
 	})
 
 	It("returns the default value if the key is not defined", func() {
@@ -92,7 +109,7 @@ func ExampleGetInt8Default() {
 }
 
 var _ = Describe("func MustGetInt8()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v, ok := MustGetInt8(b, "<key>")
@@ -133,7 +150,7 @@ func ExampleMustGetInt8() {
 }
 
 var _ = Describe("func MustGetInt8Default()", func() {
-	It("returns the integer value", func() {
+	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
 
 		v := MustGetInt8Default(b, "<key>", -10)

--- a/config/int8_test.go
+++ b/config/int8_test.go
@@ -117,6 +117,14 @@ var _ = Describe("func MustGetInt8()", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt8(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
@@ -155,6 +163,13 @@ var _ = Describe("func MustGetInt8Default()", func() {
 
 		v := MustGetInt8Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v := MustGetInt8Default(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {

--- a/config/int8_test.go
+++ b/config/int8_test.go
@@ -10,11 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("func GetInt64()", func() {
+var _ = Describe("func GetInt8()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v, ok, err := GetInt64(b, "<key>")
+		v, ok, err := GetInt8(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
 		Expect(ok).To(BeTrue())
@@ -23,7 +23,7 @@ var _ = Describe("func GetInt64()", func() {
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
-		_, ok, err := GetInt64(b, "<key>")
+		_, ok, err := GetInt8(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(ok).To(BeFalse())
 	})
@@ -31,15 +31,15 @@ var _ = Describe("func GetInt64()", func() {
 	It("returns an error if the value can not be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
-		_, _, err := GetInt64(b, "<key>")
-		Expect(err).To(MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+		_, _, err := GetInt8(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid signed 8-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
 
-func ExampleGetInt64() {
+func ExampleGetInt8() {
 	os.Setenv("FOO", "123")
 
-	v, ok, err := config.GetInt64(config.Environment(), "FOO")
+	v, ok, err := config.GetInt8(config.Environment(), "FOO")
 	if err != nil {
 		panic(err)
 	}
@@ -53,11 +53,11 @@ func ExampleGetInt64() {
 	// Output: the value is 123!
 }
 
-var _ = Describe("func GetInt64Default()", func() {
+var _ = Describe("func GetInt8Default()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v, err := GetInt64Default(b, "<key>", -10)
+		v, err := GetInt8Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(123))
 	})
@@ -65,7 +65,7 @@ var _ = Describe("func GetInt64Default()", func() {
 	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
-		v, err := GetInt64Default(b, "<key>", -10)
+		v, err := GetInt8Default(b, "<key>", -10)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(BeEquivalentTo(-10))
 	})
@@ -73,15 +73,15 @@ var _ = Describe("func GetInt64Default()", func() {
 	It("returns an error if the value can not be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
-		_, err := GetInt64Default(b, "<key>", -10)
-		Expect(err).To(MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+		_, err := GetInt8Default(b, "<key>", -10)
+		Expect(err).To(MatchError(`<key> is not a valid signed 8-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
 
-func ExampleGetInt64Default() {
+func ExampleGetInt8Default() {
 	os.Setenv("FOO", "123")
 
-	v, err := config.GetInt64Default(config.Environment(), "FOO", -10)
+	v, err := config.GetInt8Default(config.Environment(), "FOO", -10)
 	if err != nil {
 		panic(err)
 	}
@@ -91,11 +91,11 @@ func ExampleGetInt64Default() {
 	// Output: the value is 123!
 }
 
-var _ = Describe("func MustGetInt64()", func() {
+var _ = Describe("func MustGetInt8()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v, ok := MustGetInt64(b, "<key>")
+		v, ok := MustGetInt8(b, "<key>")
 		Expect(v).To(BeEquivalentTo(123))
 		Expect(ok).To(BeTrue())
 	})
@@ -103,7 +103,7 @@ var _ = Describe("func MustGetInt64()", func() {
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
-		_, ok := MustGetInt64(b, "<key>")
+		_, ok := MustGetInt8(b, "<key>")
 		Expect(ok).To(BeFalse())
 	})
 
@@ -111,17 +111,17 @@ var _ = Describe("func MustGetInt64()", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
-			MustGetInt64(b, "<key>")
+			MustGetInt8(b, "<key>")
 		}).To(PanicWith(
-			MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+			MatchError(`<key> is not a valid signed 8-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
 		))
 	})
 })
 
-func ExampleMustGetInt64() {
+func ExampleMustGetInt8() {
 	os.Setenv("FOO", "123")
 
-	v, ok := config.MustGetInt64(config.Environment(), "FOO")
+	v, ok := config.MustGetInt8(config.Environment(), "FOO")
 
 	if !ok {
 		fmt.Println("key is not defined!")
@@ -132,18 +132,18 @@ func ExampleMustGetInt64() {
 	// Output: the value is 123!
 }
 
-var _ = Describe("func MustGetInt64Default()", func() {
+var _ = Describe("func MustGetInt8Default()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}
 
-		v := MustGetInt64Default(b, "<key>", -10)
+		v := MustGetInt8Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
 	})
 
 	It("returns the default value if the key is not defined", func() {
 		b := Map{}
 
-		v := MustGetInt64Default(b, "<key>", -10)
+		v := MustGetInt8Default(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
@@ -151,17 +151,17 @@ var _ = Describe("func MustGetInt64Default()", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
-			MustGetInt64Default(b, "<key>", -10)
+			MustGetInt8Default(b, "<key>", -10)
 		}).To(PanicWith(
-			MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+			MatchError(`<key> is not a valid signed 8-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
 		))
 	})
 })
 
-func ExampleMustGetInt64Default() {
+func ExampleMustGetInt8Default() {
 	os.Setenv("FOO", "123")
 
-	v := config.MustGetInt64Default(config.Environment(), "FOO", -10)
+	v := config.MustGetInt8Default(config.Environment(), "FOO", -10)
 
 	fmt.Printf("the value is %d!\n", v)
 

--- a/config/int8_test.go
+++ b/config/int8_test.go
@@ -1,10 +1,6 @@
 package config_test
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/dogmatiq/dodeca/config"
 	. "github.com/dogmatiq/dodeca/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,23 +41,6 @@ var _ = Describe("func GetInt8()", func() {
 	})
 })
 
-func ExampleGetInt8() {
-	os.Setenv("FOO", "123")
-
-	v, ok, err := config.GetInt8(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func GetInt8Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -94,19 +73,6 @@ var _ = Describe("func GetInt8Default()", func() {
 		Expect(err).To(MatchError(`<key> is not a valid signed 8-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
 	})
 })
-
-func ExampleGetInt8Default() {
-	os.Setenv("FOO", "123")
-
-	v, err := config.GetInt8Default(config.Environment(), "FOO", -10)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}
 
 var _ = Describe("func MustGetInt8()", func() {
 	It("returns a positive integer value", func() {
@@ -143,20 +109,6 @@ var _ = Describe("func MustGetInt8()", func() {
 	})
 })
 
-func ExampleMustGetInt8() {
-	os.Setenv("FOO", "123")
-
-	v, ok := config.MustGetInt8(config.Environment(), "FOO")
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func MustGetInt8Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -189,13 +141,3 @@ var _ = Describe("func MustGetInt8Default()", func() {
 		))
 	})
 })
-
-func ExampleMustGetInt8Default() {
-	os.Setenv("FOO", "123")
-
-	v := config.MustGetInt8Default(config.Environment(), "FOO", -10)
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}

--- a/config/int8_test.go
+++ b/config/int8_test.go
@@ -33,7 +33,7 @@ var _ = Describe("func GetInt8()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetInt8(b, "<key>")
@@ -66,7 +66,7 @@ var _ = Describe("func GetInt8Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetInt8Default(b, "<key>", -10)
@@ -98,7 +98,7 @@ var _ = Describe("func MustGetInt8()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -131,7 +131,7 @@ var _ = Describe("func MustGetInt8Default()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -96,16 +96,16 @@ var _ = Describe("func GetIntDefault()", func() {
 })
 
 func ExampleGetIntDefault() {
-	os.Setenv("FOO", "123")
+	os.Setenv("FOO", "")
 
-	v, err := config.GetIntDefault(config.Environment(), "FOO", -10)
+	v, err := config.GetIntDefault(config.Environment(), "FOO", -456)
 	if err != nil {
 		panic(err)
 	}
 
 	fmt.Printf("the value is %d!\n", v)
 
-	// Output: the value is 123!
+	// Output: the value is -456!
 }
 
 var _ = Describe("func MustGetInt()", func() {

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -37,7 +37,7 @@ var _ = Describe("func GetInt()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetInt(b, "<key>")
@@ -87,7 +87,7 @@ var _ = Describe("func GetIntDefault()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetIntDefault(b, "<key>", -10)
@@ -132,7 +132,7 @@ var _ = Describe("func MustGetInt()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -179,7 +179,7 @@ var _ = Describe("func MustGetIntDefault()", func() {
 		Expect(v).To(BeEquivalentTo(-10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -53,6 +53,44 @@ func ExampleGetInt64() {
 	// Output: the value is 123!
 }
 
+var _ = Describe("func GetInt64Default()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetInt64Default(b, "<key>", 456)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetInt64Default(b, "<key>", 456)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(456))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetInt64Default(b, "<key>", 456)
+		Expect(err).To(MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt64Default() {
+	os.Setenv("FOO", "123")
+
+	v, err := config.GetInt64Default(config.Environment(), "FOO", 456)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}
+
 var _ = Describe("func MustGetInt64()", func() {
 	It("returns the integer value", func() {
 		b := Map{"<key>": String("123")}

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -191,11 +191,11 @@ var _ = Describe("func MustGetIntDefault()", func() {
 })
 
 func ExampleMustGetIntDefault() {
-	os.Setenv("FOO", "123")
+	os.Setenv("FOO", "")
 
-	v := config.MustGetIntDefault(config.Environment(), "FOO", -10)
+	v := config.MustGetIntDefault(config.Environment(), "FOO", -456)
 
 	fmt.Printf("the value is %d!\n", v)
 
-	// Output: the value is 123!
+	// Output: the value is -456!
 }

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -1,0 +1,186 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetInt()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetInt(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok, err := GetInt(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetInt(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetInt(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid signed integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt() {
+	os.Setenv("FOO", "123")
+
+	v, ok, err := config.GetInt(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func GetIntDefault()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetIntDefault(b, "<key>", -10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetIntDefault(b, "<key>", -10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(-10))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetIntDefault(b, "<key>", -10)
+		Expect(err).To(MatchError(`<key> is not a valid signed integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetIntDefault() {
+	os.Setenv("FOO", "123")
+
+	v, err := config.GetIntDefault(config.Environment(), "FOO", -10)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetInt()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetInt(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetInt(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt() {
+	os.Setenv("FOO", "123")
+
+	v, ok := config.MustGetInt(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetIntDefault()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetIntDefault(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetIntDefault(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-10))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetIntDefault(b, "<key>", -10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetIntDefault() {
+	os.Setenv("FOO", "123")
+
+	v := config.MustGetIntDefault(config.Environment(), "FOO", -10)
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -1,0 +1,54 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetInt64()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetInt64(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetInt64(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetInt64(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`))
+	})
+})
+
+func ExampleGetInt64() {
+	os.Setenv("FOO", "123")
+
+	v, ok, err := config.GetInt64(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -52,3 +52,44 @@ func ExampleGetInt64() {
 
 	// Output: the value is 123!
 }
+
+var _ = Describe("func MustGetInt64()", func() {
+	It("returns the integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetInt64(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetInt64(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetInt64(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid signed 64-bit integer: strconv.ParseInt: parsing "<invalid>": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetInt64() {
+	os.Setenv("FOO", "123")
+
+	v, ok := config.MustGetInt64(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}

--- a/config/int_test.go
+++ b/config/int_test.go
@@ -117,6 +117,14 @@ var _ = Describe("func MustGetInt()", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v, ok := MustGetInt(b, "<key>")
+		Expect(v).To(BeEquivalentTo(-123))
+		Expect(ok).To(BeTrue())
+	})
+
 	It("sets ok to false if the key is not defined", func() {
 		b := Map{}
 
@@ -155,6 +163,13 @@ var _ = Describe("func MustGetIntDefault()", func() {
 
 		v := MustGetIntDefault(b, "<key>", -10)
 		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns a negative integer value", func() {
+		b := Map{"<key>": String("-123")}
+
+		v := MustGetIntDefault(b, "<key>", -10)
+		Expect(v).To(BeEquivalentTo(-123))
 	})
 
 	It("returns the default value if the key is not defined", func() {

--- a/config/uint.go
+++ b/config/uint.go
@@ -9,15 +9,15 @@ import (
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an uint, err is a non-nil
+// error describing the invalid value.
 func GetUint(b Bucket, k string) (v uint, ok bool, err error) {
 	v64, ok, err := getUint(b, k, 0)
 	return uint(v64), ok, err
 }
 
-// GetUintDefault returns the uint representation of the value associated
-// with k, or the default value v if k is undefined.
+// GetUintDefault returns the uint representation of the value associated with
+// k, or the default value v if k is undefined.
 //
 // If k is defined but its value can not be parsed as an uint, it returns an
 // error describing the invalid value.
@@ -34,8 +34,7 @@ func GetUintDefault(b Bucket, k string, v uint) (uint, error) {
 	return v, nil
 }
 
-// MustGetUint returns the uint representation of the value associated with
-// k.
+// MustGetUint returns the uint representation of the value associated with k.
 //
 // If k is undefined, ok is false.
 //
@@ -49,8 +48,8 @@ func MustGetUint(b Bucket, k string) (v uint, ok bool) {
 	return v, ok
 }
 
-// MustGetUintDefault returns the uint representation of the value
-// associated with k, or the default value v if k is undefined.
+// MustGetUintDefault returns the uint representation of the value associated
+// with k, or the default value v if k is undefined.
 //
 // It panics if k is defined but its value can not be parsed as an uint.
 func MustGetUintDefault(b Bucket, k string, v uint) uint {

--- a/config/uint.go
+++ b/config/uint.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetUint returns the uint representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an uint, err is a
+// non-nil error describing the invalid value.
+func GetUint(b Bucket, k string) (v uint, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseUint(s, 10, 0)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid unsigned integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return uint(v64), true, nil
+}
+
+// GetUintDefault returns the uint representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an uint, it returns an
+// error describing the invalid value.
+func GetUintDefault(b Bucket, k string, v uint) (uint, error) {
+	x, ok, err := GetUint(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetUint returns the uint representation of the value associated with
+// k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an uint.
+func MustGetUint(b Bucket, k string) (v uint, ok bool) {
+	v, ok, err := GetUint(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetUintDefault returns the uint representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an uint.
+func MustGetUintDefault(b Bucket, k string, v uint) uint {
+	if x, ok := MustGetUint(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/uint.go
+++ b/config/uint.go
@@ -9,7 +9,7 @@ import (
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint, err is a non-nil
+// If k is defined but its value cannot be parsed as an uint, err is a non-nil
 // error describing the invalid value.
 func GetUint(b Bucket, k string) (v uint, ok bool, err error) {
 	v64, ok, err := getUint(b, k, 0)
@@ -19,7 +19,7 @@ func GetUint(b Bucket, k string) (v uint, ok bool, err error) {
 // GetUintDefault returns the uint representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an uint, it returns an
+// If k is defined but its value cannot be parsed as an uint, it returns an
 // error describing the invalid value.
 func GetUintDefault(b Bucket, k string, v uint) (uint, error) {
 	x, ok, err := GetUint(b, k)
@@ -38,7 +38,7 @@ func GetUintDefault(b Bucket, k string, v uint) (uint, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an uint.
+// It panics if k is defined but its value cannot be parsed as an uint.
 func MustGetUint(b Bucket, k string) (v uint, ok bool) {
 	v, ok, err := GetUint(b, k)
 	if err != nil {
@@ -51,7 +51,7 @@ func MustGetUint(b Bucket, k string) (v uint, ok bool) {
 // MustGetUintDefault returns the uint representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an uint.
+// It panics if k is defined but its value cannot be parsed as an uint.
 func MustGetUintDefault(b Bucket, k string, v uint) uint {
 	if x, ok := MustGetUint(b, k); ok {
 		return x

--- a/config/uint16.go
+++ b/config/uint16.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetUint16 returns the uint16 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an uint16, err is a
+// non-nil error describing the invalid value.
+func GetUint16(b Bucket, k string) (v uint16, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid unsigned 16-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return uint16(v64), true, nil
+}
+
+// GetUint16Default returns the uint16 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an uint16, it returns an
+// error describing the invalid value.
+func GetUint16Default(b Bucket, k string, v uint16) (uint16, error) {
+	x, ok, err := GetUint16(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetUint16 returns the uint16 representation of the value associated with
+// k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an uint16.
+func MustGetUint16(b Bucket, k string) (v uint16, ok bool) {
+	v, ok, err := GetUint16(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetUint16Default returns the uint16 representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an uint16.
+func MustGetUint16Default(b Bucket, k string, v uint16) uint16 {
+	if x, ok := MustGetUint16(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/uint16.go
+++ b/config/uint16.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetUint16 returns the uint16 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an uint16, err is a
 // non-nil error describing the invalid value.
 func GetUint16(b Bucket, k string) (v uint16, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v64, err := strconv.ParseUint(s, 10, 16)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid unsigned 16-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return uint16(v64), true, nil
+	v64, ok, err := getUint(b, k, 16)
+	return uint16(v64), ok, err
 }
 
 // GetUint16Default returns the uint16 representation of the value associated

--- a/config/uint16.go
+++ b/config/uint16.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint16, err is a
+// If k is defined but its value cannot be parsed as an uint16, err is a
 // non-nil error describing the invalid value.
 func GetUint16(b Bucket, k string) (v uint16, ok bool, err error) {
 	v64, ok, err := getUint(b, k, 16)
@@ -14,7 +14,7 @@ func GetUint16(b Bucket, k string) (v uint16, ok bool, err error) {
 // GetUint16Default returns the uint16 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an uint16, it returns an
+// If k is defined but its value cannot be parsed as an uint16, it returns an
 // error describing the invalid value.
 func GetUint16Default(b Bucket, k string, v uint16) (uint16, error) {
 	x, ok, err := GetUint16(b, k)
@@ -34,7 +34,7 @@ func GetUint16Default(b Bucket, k string, v uint16) (uint16, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an uint16.
+// It panics if k is defined but its value cannot be parsed as an uint16.
 func MustGetUint16(b Bucket, k string) (v uint16, ok bool) {
 	v, ok, err := GetUint16(b, k)
 	if err != nil {
@@ -47,7 +47,7 @@ func MustGetUint16(b Bucket, k string) (v uint16, ok bool) {
 // MustGetUint16Default returns the uint16 representation of the value
 // associated with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an uint16.
+// It panics if k is defined but its value cannot be parsed as an uint16.
 func MustGetUint16Default(b Bucket, k string, v uint16) uint16 {
 	if x, ok := MustGetUint16(b, k); ok {
 		return x

--- a/config/uint16_test.go
+++ b/config/uint16_test.go
@@ -1,0 +1,145 @@
+package config_test
+
+import (
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetUint16()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetUint16(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetUint16(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetUint16(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, _, err := GetUint16(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+var _ = Describe("func GetUint16Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetUint16Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetUint16Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetUint16Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, err := GetUint16Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+var _ = Describe("func MustGetUint16()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetUint16(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetUint16(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint16(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint16(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+var _ = Describe("func MustGetUint16Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetUint16Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetUint16Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint16Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint16Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 16-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})

--- a/config/uint16_test.go
+++ b/config/uint16_test.go
@@ -24,7 +24,7 @@ var _ = Describe("func GetUint16()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetUint16(b, "<key>")
@@ -56,7 +56,7 @@ var _ = Describe("func GetUint16Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetUint16Default(b, "<key>", 10)
@@ -87,7 +87,7 @@ var _ = Describe("func MustGetUint16()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -123,7 +123,7 @@ var _ = Describe("func MustGetUint16Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/uint32.go
+++ b/config/uint32.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint32, err is a
+// If k is defined but its value cannot be parsed as an uint32, err is a
 // non-nil error describing the invalid value.
 func GetUint32(b Bucket, k string) (v uint32, ok bool, err error) {
 	v64, ok, err := getUint(b, k, 32)
@@ -14,7 +14,7 @@ func GetUint32(b Bucket, k string) (v uint32, ok bool, err error) {
 // GetUint32Default returns the uint32 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an uint32, it returns an
+// If k is defined but its value cannot be parsed as an uint32, it returns an
 // error describing the invalid value.
 func GetUint32Default(b Bucket, k string, v uint32) (uint32, error) {
 	x, ok, err := GetUint32(b, k)
@@ -34,7 +34,7 @@ func GetUint32Default(b Bucket, k string, v uint32) (uint32, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an uint32.
+// It panics if k is defined but its value cannot be parsed as an uint32.
 func MustGetUint32(b Bucket, k string) (v uint32, ok bool) {
 	v, ok, err := GetUint32(b, k)
 	if err != nil {
@@ -47,7 +47,7 @@ func MustGetUint32(b Bucket, k string) (v uint32, ok bool) {
 // MustGetUint32Default returns the uint32 representation of the value
 // associated with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an uint32.
+// It panics if k is defined but its value cannot be parsed as an uint32.
 func MustGetUint32Default(b Bucket, k string, v uint32) uint32 {
 	if x, ok := MustGetUint32(b, k); ok {
 		return x

--- a/config/uint32.go
+++ b/config/uint32.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetUint32 returns the uint32 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an uint32, err is a
+// non-nil error describing the invalid value.
+func GetUint32(b Bucket, k string) (v uint32, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid unsigned 32-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return uint32(v64), true, nil
+}
+
+// GetUint32Default returns the uint32 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an uint32, it returns an
+// error describing the invalid value.
+func GetUint32Default(b Bucket, k string, v uint32) (uint32, error) {
+	x, ok, err := GetUint32(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetUint32 returns the uint32 representation of the value associated with
+// k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an uint32.
+func MustGetUint32(b Bucket, k string) (v uint32, ok bool) {
+	v, ok, err := GetUint32(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetUint32Default returns the uint32 representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an uint32.
+func MustGetUint32Default(b Bucket, k string, v uint32) uint32 {
+	if x, ok := MustGetUint32(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/uint32.go
+++ b/config/uint32.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetUint32 returns the uint32 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an uint32, err is a
 // non-nil error describing the invalid value.
 func GetUint32(b Bucket, k string) (v uint32, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v64, err := strconv.ParseUint(s, 10, 32)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid unsigned 32-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return uint32(v64), true, nil
+	v64, ok, err := getUint(b, k, 32)
+	return uint32(v64), ok, err
 }
 
 // GetUint32Default returns the uint32 representation of the value associated

--- a/config/uint32_test.go
+++ b/config/uint32_test.go
@@ -1,0 +1,145 @@
+package config_test
+
+import (
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetUint32()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetUint32(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetUint32(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetUint32(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, _, err := GetUint32(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+var _ = Describe("func GetUint32Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetUint32Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetUint32Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetUint32Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, err := GetUint32Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+var _ = Describe("func MustGetUint32()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetUint32(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetUint32(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint32(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint32(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+var _ = Describe("func MustGetUint32Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetUint32Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetUint32Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint32Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint32Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 32-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})

--- a/config/uint32_test.go
+++ b/config/uint32_test.go
@@ -24,7 +24,7 @@ var _ = Describe("func GetUint32()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetUint32(b, "<key>")
@@ -56,7 +56,7 @@ var _ = Describe("func GetUint32Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetUint32Default(b, "<key>", 10)
@@ -87,7 +87,7 @@ var _ = Describe("func MustGetUint32()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -123,7 +123,7 @@ var _ = Describe("func MustGetUint32Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/uint64.go
+++ b/config/uint64.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint64, err is a
+// If k is defined but its value cannot be parsed as an uint64, err is a
 // non-nil error describing the invalid value.
 func GetUint64(b Bucket, k string) (v uint64, ok bool, err error) {
 	v, ok, err = getUint(b, k, 64)
@@ -14,7 +14,7 @@ func GetUint64(b Bucket, k string) (v uint64, ok bool, err error) {
 // GetUint64Default returns the uint64 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an uint64, it returns an
+// If k is defined but its value cannot be parsed as an uint64, it returns an
 // error describing the invalid value.
 func GetUint64Default(b Bucket, k string, v uint64) (uint64, error) {
 	x, ok, err := GetUint64(b, k)
@@ -34,7 +34,7 @@ func GetUint64Default(b Bucket, k string, v uint64) (uint64, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an uint64.
+// It panics if k is defined but its value cannot be parsed as an uint64.
 func MustGetUint64(b Bucket, k string) (v uint64, ok bool) {
 	v, ok, err := GetUint64(b, k)
 	if err != nil {
@@ -47,7 +47,7 @@ func MustGetUint64(b Bucket, k string) (v uint64, ok bool) {
 // MustGetUint64Default returns the uint64 representation of the value
 // associated with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an uint64.
+// It panics if k is defined but its value cannot be parsed as an uint64.
 func MustGetUint64Default(b Bucket, k string, v uint64) uint64 {
 	if x, ok := MustGetUint64(b, k); ok {
 		return x

--- a/config/uint64.go
+++ b/config/uint64.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetUint64 returns the uint64 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an uint64, err is a
 // non-nil error describing the invalid value.
 func GetUint64(b Bucket, k string) (v uint64, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v, err = strconv.ParseUint(s, 10, 64)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid unsigned 64-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return v, true, nil
+	v, ok, err = getUint(b, k, 64)
+	return v, ok, err
 }
 
 // GetUint64Default returns the uint64 representation of the value associated

--- a/config/uint64.go
+++ b/config/uint64.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetUint64 returns the uint64 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an uint64, err is a
+// non-nil error describing the invalid value.
+func GetUint64(b Bucket, k string) (v uint64, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v, err = strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid unsigned 64-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return v, true, nil
+}
+
+// GetUint64Default returns the uint64 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an uint64, it returns an
+// error describing the invalid value.
+func GetUint64Default(b Bucket, k string, v uint64) (uint64, error) {
+	x, ok, err := GetUint64(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetUint64 returns the uint64 representation of the value associated with
+// k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an uint64.
+func MustGetUint64(b Bucket, k string) (v uint64, ok bool) {
+	v, ok, err := GetUint64(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetUint64Default returns the uint64 representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an uint64.
+func MustGetUint64Default(b Bucket, k string, v uint64) uint64 {
+	if x, ok := MustGetUint64(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/uint64_test.go
+++ b/config/uint64_test.go
@@ -1,10 +1,6 @@
 package config_test
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/dogmatiq/dodeca/config"
 	. "github.com/dogmatiq/dodeca/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -43,23 +39,6 @@ var _ = Describe("func GetUint64()", func() {
 	})
 })
 
-func ExampleGetUint64() {
-	os.Setenv("FOO", "123")
-
-	v, ok, err := config.GetUint64(config.Environment(), "FOO")
-	if err != nil {
-		panic(err)
-	}
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func GetUint64Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -91,19 +70,6 @@ var _ = Describe("func GetUint64Default()", func() {
 		Expect(err).To(MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
 	})
 })
-
-func ExampleGetUint64Default() {
-	os.Setenv("FOO", "123")
-
-	v, err := config.GetUint64Default(config.Environment(), "FOO", 10)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}
 
 var _ = Describe("func MustGetUint64()", func() {
 	It("returns a positive integer value", func() {
@@ -142,20 +108,6 @@ var _ = Describe("func MustGetUint64()", func() {
 	})
 })
 
-func ExampleMustGetUint64() {
-	os.Setenv("FOO", "123")
-
-	v, ok := config.MustGetUint64(config.Environment(), "FOO")
-
-	if !ok {
-		fmt.Println("key is not defined!")
-	} else {
-		fmt.Printf("the value is %d!\n", v)
-	}
-
-	// Output: the value is 123!
-}
-
 var _ = Describe("func MustGetUint64Default()", func() {
 	It("returns a positive integer value", func() {
 		b := Map{"<key>": String("123")}
@@ -191,13 +143,3 @@ var _ = Describe("func MustGetUint64Default()", func() {
 		))
 	})
 })
-
-func ExampleMustGetUint64Default() {
-	os.Setenv("FOO", "123")
-
-	v := config.MustGetUint64Default(config.Environment(), "FOO", 10)
-
-	fmt.Printf("the value is %d!\n", v)
-
-	// Output: the value is 123!
-}

--- a/config/uint64_test.go
+++ b/config/uint64_test.go
@@ -1,0 +1,203 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetUint64()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetUint64(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetUint64(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetUint64(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, _, err := GetUint64(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+func ExampleGetUint64() {
+	os.Setenv("FOO", "123")
+
+	v, ok, err := config.GetUint64(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func GetUint64Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetUint64Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetUint64Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetUint64Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, err := GetUint64Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+func ExampleGetUint64Default() {
+	os.Setenv("FOO", "123")
+
+	v, err := config.GetUint64Default(config.Environment(), "FOO", 10)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetUint64()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetUint64(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetUint64(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint64(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint64(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetUint64() {
+	os.Setenv("FOO", "123")
+
+	v, ok := config.MustGetUint64(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetUint64Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetUint64Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetUint64Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint64Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint64Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 64-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetUint64Default() {
+	os.Setenv("FOO", "123")
+
+	v := config.MustGetUint64Default(config.Environment(), "FOO", 10)
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}

--- a/config/uint64_test.go
+++ b/config/uint64_test.go
@@ -24,7 +24,7 @@ var _ = Describe("func GetUint64()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetUint64(b, "<key>")
@@ -56,7 +56,7 @@ var _ = Describe("func GetUint64Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetUint64Default(b, "<key>", 10)
@@ -87,7 +87,7 @@ var _ = Describe("func MustGetUint64()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -123,7 +123,7 @@ var _ = Describe("func MustGetUint64Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/uint8.go
+++ b/config/uint8.go
@@ -4,15 +4,15 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint8, err is a
-// non-nil error describing the invalid value.
+// If k is defined but its value can not be parsed as an uint8, err is a non-nil
+// error describing the invalid value.
 func GetUint8(b Bucket, k string) (v uint8, ok bool, err error) {
 	v64, ok, err := getUint(b, k, 8)
 	return uint8(v64), ok, err
 }
 
-// GetUint8Default returns the uint8 representation of the value associated
-// with k, or the default value v if k is undefined.
+// GetUint8Default returns the uint8 representation of the value associated with
+// k, or the default value v if k is undefined.
 //
 // If k is defined but its value can not be parsed as an uint8, it returns an
 // error describing the invalid value.
@@ -29,8 +29,7 @@ func GetUint8Default(b Bucket, k string, v uint8) (uint8, error) {
 	return v, nil
 }
 
-// MustGetUint8 returns the uint8 representation of the value associated with
-// k.
+// MustGetUint8 returns the uint8 representation of the value associated with k.
 //
 // If k is undefined, ok is false.
 //
@@ -44,8 +43,8 @@ func MustGetUint8(b Bucket, k string) (v uint8, ok bool) {
 	return v, ok
 }
 
-// MustGetUint8Default returns the uint8 representation of the value
-// associated with k, or the default value v if k is undefined.
+// MustGetUint8Default returns the uint8 representation of the value associated
+// with k, or the default value v if k is undefined.
 //
 // It panics if k is defined but its value can not be parsed as an uint8.
 func MustGetUint8Default(b Bucket, k string, v uint8) uint8 {

--- a/config/uint8.go
+++ b/config/uint8.go
@@ -4,7 +4,7 @@ package config
 //
 // If k is undefined, ok is false and err is nil.
 //
-// If k is defined but its value can not be parsed as an uint8, err is a non-nil
+// If k is defined but its value cannot be parsed as an uint8, err is a non-nil
 // error describing the invalid value.
 func GetUint8(b Bucket, k string) (v uint8, ok bool, err error) {
 	v64, ok, err := getUint(b, k, 8)
@@ -14,7 +14,7 @@ func GetUint8(b Bucket, k string) (v uint8, ok bool, err error) {
 // GetUint8Default returns the uint8 representation of the value associated with
 // k, or the default value v if k is undefined.
 //
-// If k is defined but its value can not be parsed as an uint8, it returns an
+// If k is defined but its value cannot be parsed as an uint8, it returns an
 // error describing the invalid value.
 func GetUint8Default(b Bucket, k string, v uint8) (uint8, error) {
 	x, ok, err := GetUint8(b, k)
@@ -33,7 +33,7 @@ func GetUint8Default(b Bucket, k string, v uint8) (uint8, error) {
 //
 // If k is undefined, ok is false.
 //
-// It panics if k is defined but its value can not be parsed as an uint8.
+// It panics if k is defined but its value cannot be parsed as an uint8.
 func MustGetUint8(b Bucket, k string) (v uint8, ok bool) {
 	v, ok, err := GetUint8(b, k)
 	if err != nil {
@@ -46,7 +46,7 @@ func MustGetUint8(b Bucket, k string) (v uint8, ok bool) {
 // MustGetUint8Default returns the uint8 representation of the value associated
 // with k, or the default value v if k is undefined.
 //
-// It panics if k is defined but its value can not be parsed as an uint8.
+// It panics if k is defined but its value cannot be parsed as an uint8.
 func MustGetUint8Default(b Bucket, k string, v uint8) uint8 {
 	if x, ok := MustGetUint8(b, k); ok {
 		return x

--- a/config/uint8.go
+++ b/config/uint8.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetUint8 returns the uint8 representation of the value associated with k.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value can not be parsed as an uint8, err is a
+// non-nil error describing the invalid value.
+func GetUint8(b Bucket, k string) (v uint8, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v64, err := strconv.ParseUint(s, 10, 8)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid unsigned 8-bit integer: %w`,
+			k,
+			err,
+		)
+	}
+
+	return uint8(v64), true, nil
+}
+
+// GetUint8Default returns the uint8 representation of the value associated
+// with k, or the default value v if k is undefined.
+//
+// If k is defined but its value can not be parsed as an uint8, it returns an
+// error describing the invalid value.
+func GetUint8Default(b Bucket, k string, v uint8) (uint8, error) {
+	x, ok, err := GetUint8(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetUint8 returns the uint8 representation of the value associated with
+// k.
+//
+// If k is undefined, ok is false.
+//
+// It panics if k is defined but its value can not be parsed as an uint8.
+func MustGetUint8(b Bucket, k string) (v uint8, ok bool) {
+	v, ok, err := GetUint8(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetUint8Default returns the uint8 representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// It panics if k is defined but its value can not be parsed as an uint8.
+func MustGetUint8Default(b Bucket, k string, v uint8) uint8 {
+	if x, ok := MustGetUint8(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/uint8.go
+++ b/config/uint8.go
@@ -1,10 +1,5 @@
 package config
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // GetUint8 returns the uint8 representation of the value associated with k.
 //
 // If k is undefined, ok is false and err is nil.
@@ -12,27 +7,8 @@ import (
 // If k is defined but its value can not be parsed as an uint8, err is a
 // non-nil error describing the invalid value.
 func GetUint8(b Bucket, k string) (v uint8, ok bool, err error) {
-	x := b.Get(k)
-
-	if x.IsZero() {
-		return 0, false, nil
-	}
-
-	s, err := x.AsString()
-	if err != nil {
-		return 0, false, err
-	}
-
-	v64, err := strconv.ParseUint(s, 10, 8)
-	if err != nil {
-		return 0, false, fmt.Errorf(
-			`%s is not a valid unsigned 8-bit integer: %w`,
-			k,
-			err,
-		)
-	}
-
-	return uint8(v64), true, nil
+	v64, ok, err := getUint(b, k, 8)
+	return uint8(v64), ok, err
 }
 
 // GetUint8Default returns the uint8 representation of the value associated

--- a/config/uint8_test.go
+++ b/config/uint8_test.go
@@ -1,0 +1,145 @@
+package config_test
+
+import (
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetUint8()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetUint8(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetUint8(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetUint8(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, _, err := GetUint8(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+var _ = Describe("func GetUint8Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetUint8Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetUint8Default(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetUint8Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, err := GetUint8Default(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+var _ = Describe("func MustGetUint8()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetUint8(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetUint8(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint8(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint8(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+var _ = Describe("func MustGetUint8Default()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetUint8Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetUint8Default(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint8Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint8Default(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned 8-bit integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})

--- a/config/uint8_test.go
+++ b/config/uint8_test.go
@@ -24,7 +24,7 @@ var _ = Describe("func GetUint8()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetUint8(b, "<key>")
@@ -56,7 +56,7 @@ var _ = Describe("func GetUint8Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetUint8Default(b, "<key>", 10)
@@ -87,7 +87,7 @@ var _ = Describe("func MustGetUint8()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -123,7 +123,7 @@ var _ = Describe("func MustGetUint8Default()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/uint_test.go
+++ b/config/uint_test.go
@@ -1,0 +1,203 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetUint()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok, err := GetUint(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetUint(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetUint(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, _, err := GetUint(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+func ExampleGetUint() {
+	os.Setenv("FOO", "123")
+
+	v, ok, err := config.GetUint(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func GetUintDefault()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, err := GetUintDefault(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetUintDefault(b, "<key>", 10)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("returns an error if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetUintDefault(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`))
+	})
+
+	It("returns an error if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		_, err := GetUintDefault(b, "<key>", 10)
+		Expect(err).To(MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "-123": invalid syntax`))
+	})
+})
+
+func ExampleGetUintDefault() {
+	os.Setenv("FOO", "123")
+
+	v, err := config.GetUintDefault(config.Environment(), "FOO", 10)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetUint()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v, ok := MustGetUint(b, "<key>")
+		Expect(v).To(BeEquivalentTo(123))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetUint(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUint(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUint(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetUint() {
+	os.Setenv("FOO", "123")
+
+	v, ok := config.MustGetUint(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %d!\n", v)
+	}
+
+	// Output: the value is 123!
+}
+
+var _ = Describe("func MustGetUintDefault()", func() {
+	It("returns a positive integer value", func() {
+		b := Map{"<key>": String("123")}
+
+		v := MustGetUintDefault(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(123))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetUintDefault(b, "<key>", 10)
+		Expect(v).To(BeEquivalentTo(10))
+	})
+
+	It("panics if the value can not be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetUintDefault(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "<invalid>": invalid syntax`),
+		))
+	})
+
+	It("panics if the value is negative", func() {
+		b := Map{"<key>": String("-123")}
+
+		Expect(func() {
+			MustGetUintDefault(b, "<key>", 10)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid unsigned integer: strconv.ParseUint: parsing "-123": invalid syntax`),
+		))
+	})
+})
+
+func ExampleMustGetUintDefault() {
+	os.Setenv("FOO", "123")
+
+	v := config.MustGetUintDefault(config.Environment(), "FOO", 10)
+
+	fmt.Printf("the value is %d!\n", v)
+
+	// Output: the value is 123!
+}

--- a/config/uint_test.go
+++ b/config/uint_test.go
@@ -193,11 +193,11 @@ var _ = Describe("func MustGetUintDefault()", func() {
 })
 
 func ExampleMustGetUintDefault() {
-	os.Setenv("FOO", "123")
+	os.Setenv("FOO", "")
 
-	v := config.MustGetUintDefault(config.Environment(), "FOO", 10)
+	v := config.MustGetUintDefault(config.Environment(), "FOO", 456)
 
 	fmt.Printf("the value is %d!\n", v)
 
-	// Output: the value is 123!
+	// Output: the value is 456!
 }

--- a/config/uint_test.go
+++ b/config/uint_test.go
@@ -28,7 +28,7 @@ var _ = Describe("func GetUint()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, _, err := GetUint(b, "<key>")
@@ -77,7 +77,7 @@ var _ = Describe("func GetUintDefault()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("returns an error if the value can not be parsed", func() {
+	It("returns an error if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		_, err := GetUintDefault(b, "<key>", 10)
@@ -121,7 +121,7 @@ var _ = Describe("func MustGetUint()", func() {
 		Expect(ok).To(BeFalse())
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {
@@ -171,7 +171,7 @@ var _ = Describe("func MustGetUintDefault()", func() {
 		Expect(v).To(BeEquivalentTo(10))
 	})
 
-	It("panics if the value can not be parsed", func() {
+	It("panics if the value cannot be parsed", func() {
 		b := Map{"<key>": String("<invalid>")}
 
 		Expect(func() {

--- a/config/uint_test.go
+++ b/config/uint_test.go
@@ -93,16 +93,16 @@ var _ = Describe("func GetUintDefault()", func() {
 })
 
 func ExampleGetUintDefault() {
-	os.Setenv("FOO", "123")
+	os.Setenv("FOO", "")
 
-	v, err := config.GetUintDefault(config.Environment(), "FOO", 10)
+	v, err := config.GetUintDefault(config.Environment(), "FOO", 456)
 	if err != nil {
 		panic(err)
 	}
 
 	fmt.Printf("the value is %d!\n", v)
 
-	// Output: the value is 123!
+	// Output: the value is 456!
 }
 
 var _ = Describe("func MustGetUint()", func() {

--- a/config/value.go
+++ b/config/value.go
@@ -57,7 +57,7 @@ func (v Value) AsPath() (string, io.Closer, error) {
 // It returns an error v is the zero-value.
 func (v Value) AsString() (string, error) {
 	if v.src == nil {
-		return "", errors.New("can not represent a zero-value as a string")
+		return "", errors.New("cannot represent a zero-value as a string")
 	}
 
 	return v.src.AsString()
@@ -68,7 +68,7 @@ func (v Value) AsString() (string, error) {
 // If v is the zero-value, it returns a nil slice.
 func (v Value) AsBytes() ([]byte, error) {
 	if v.src == nil {
-		return nil, errors.New("can not represent a zero-value as a byte-slice")
+		return nil, errors.New("cannot represent a zero-value as a byte-slice")
 	}
 
 	return v.src.AsBytes()

--- a/config/value_test.go
+++ b/config/value_test.go
@@ -27,7 +27,7 @@ func TestValue_AsPath_withZeroValue(t *testing.T) {
 func TestValue_AsString_withZeroValue(t *testing.T) {
 	_, err := Value{}.AsString()
 
-	if err == nil || err.Error() != "can not represent a zero-value as a string" {
+	if err == nil || err.Error() != "cannot represent a zero-value as a string" {
 		t.Fatal("unexpected error, got:", err)
 	}
 }
@@ -35,7 +35,7 @@ func TestValue_AsString_withZeroValue(t *testing.T) {
 func TestValue_AsBytes_withZeroValue(t *testing.T) {
 	_, err := Value{}.AsBytes()
 
-	if err == nil || err.Error() != "can not represent a zero-value as a byte-slice" {
+	if err == nil || err.Error() != "cannot represent a zero-value as a byte-slice" {
 		t.Fatal("unexpected error, got:", err)
 	}
 }
@@ -54,7 +54,7 @@ func TestValue_String_withZeroValue(t *testing.T) {
 
 		switch e := p.(type) {
 		case error:
-			if e.Error() != "can not represent a zero-value as a string" {
+			if e.Error() != "cannot represent a zero-value as a string" {
 				t.Fatalf("expected panic did not occur, got: %s", p)
 			}
 		default:
@@ -79,7 +79,7 @@ func TestValue_Bytes_withZeroValue(t *testing.T) {
 
 		switch e := p.(type) {
 		case error:
-			if e.Error() != "can not represent a zero-value as a byte-slice" {
+			if e.Error() != "cannot represent a zero-value as a byte-slice" {
 				t.Fatalf("expected panic did not occur, got: %s", p)
 			}
 		default:


### PR DESCRIPTION
Partially addresses #33 


This PR adds several new helper functions for reading configuration values from a config.Bucket and parsing them as integers.

There are variants for all of the `int` and `uint` sizes. Having them makes it easy to supply an integer of the size required by something you are initialising without having to perform range validation yourself.