### PR TITLE
Add `GetDurationXXX()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Add `GetBool()` and its variants for reading boolean configuration values
 - Add `GetInt()` and its variants for reading integer configuration values
 - Add `GetFloat[32|64]()` and their variants for reading floating-point configuration values
+- Add `GetDuration()` and its variants for reading time duration configuration values
 
 ## [0.2.2] - 2020-09-04
 

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// GetDuration returns the time.Duration representation of the value associated
+// with k.
+//
+// Durations are specified using the syntax supported by time.ParseDuration.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// If k is defined but its value cannot be parsed as a duration, err is a
+// non-nil error describing the invalid value.
+func GetDuration(b Bucket, k string) (v time.Duration, ok bool, err error) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return 0, false, nil
+	}
+
+	s, err := x.AsString()
+	if err != nil {
+		return 0, false, err
+	}
+
+	v, err = time.ParseDuration(s)
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			`%s is not a valid duration: %w`,
+			k,
+			err,
+		)
+	}
+
+	return v, true, nil
+}
+
+// GetDurationDefault returns the time.Duration representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// Durations are specified using the syntax supported by time.ParseDuration.
+//
+// If k is defined but its value cannot be parsed as a duration, it returns an
+// error describing the invalid value.
+func GetDurationDefault(b Bucket, k string, v time.Duration) (time.Duration, error) {
+	x, ok, err := GetDuration(b, k)
+	if err != nil {
+		return 0, err
+	}
+
+	if ok {
+		return x, nil
+	}
+
+	return v, nil
+}
+
+// MustGetDuration returns the time.Duration representation of the value
+// associated with k.
+//
+// Durations are specified using the syntax supported by time.ParseDuration.
+//
+// If k is undefined, ok is false and err is nil.
+//
+// It panics if k is defined but its value cannot be parsed as a duration.
+func MustGetDuration(b Bucket, k string) (time.Duration, bool) {
+	v, ok, err := GetDuration(b, k)
+	if err != nil {
+		panic(err)
+	}
+
+	return v, ok
+}
+
+// MustGetDurationDefault returns the time.Duration representation of the value
+// associated with k, or the default value v if k is undefined.
+//
+// Durations are specified using the syntax supported by time.ParseDuration.
+//
+// It panics if k is defined but its value cannot be parsed as a duration.
+func MustGetDurationDefault(b Bucket, k string, v time.Duration) time.Duration {
+	if x, ok := MustGetDuration(b, k); ok {
+		return x
+	}
+
+	return v
+}

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -1,0 +1,170 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/dogmatiq/dodeca/config"
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func GetDuration()", func() {
+	It("returns a duration value", func() {
+		b := Map{"<key>": String("123ms")}
+
+		v, ok, err := GetDuration(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(Equal(123 * time.Millisecond))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok, err := GetDuration(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns an error if the value cannot be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, _, err := GetDuration(b, "<key>")
+		Expect(err).To(MatchError(`<key> is not a valid duration: time: invalid duration "<invalid>"`))
+	})
+})
+
+func ExampleGetDuration() {
+	os.Setenv("FOO", "100ms")
+
+	v, ok, err := config.GetDuration(config.Environment(), "FOO")
+	if err != nil {
+		panic(err)
+	}
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %s!\n", v)
+	}
+
+	// Output: the value is 100ms!
+}
+
+var _ = Describe("func GetDurationDefault()", func() {
+	It("returns a duration value", func() {
+		b := Map{"<key>": String("123ms")}
+
+		v, err := GetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(Equal(123 * time.Millisecond))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v, err := GetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(Equal(456 * time.Millisecond))
+	})
+
+	It("returns an error if the value cannot be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		_, err := GetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(err).To(MatchError(`<key> is not a valid duration: time: invalid duration "<invalid>"`))
+	})
+})
+
+func ExampleGetDurationDefault() {
+	os.Setenv("FOO", "")
+
+	v, err := config.GetDurationDefault(config.Environment(), "FOO", 200*time.Millisecond)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("the value is %s!\n", v)
+
+	// Output: the value is 200ms!
+}
+
+var _ = Describe("func MustGetDuration()", func() {
+	It("returns a duration value", func() {
+		b := Map{"<key>": String("123ms")}
+
+		v, ok := MustGetDuration(b, "<key>")
+		Expect(v).To(Equal(123 * time.Millisecond))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("sets ok to false if the key is not defined", func() {
+		b := Map{}
+
+		_, ok := MustGetDuration(b, "<key>")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("panics if the value cannot be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetDuration(b, "<key>")
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid duration: time: invalid duration "<invalid>"`),
+		))
+	})
+})
+
+func ExampleMustGetDuration() {
+	os.Setenv("FOO", "100ms")
+
+	v, ok := config.MustGetDuration(config.Environment(), "FOO")
+
+	if !ok {
+		fmt.Println("key is not defined!")
+	} else {
+		fmt.Printf("the value is %s!\n", v)
+	}
+
+	// Output: the value is 100ms!
+}
+
+var _ = Describe("func MustGetDurationDefault()", func() {
+	It("returns a duration value", func() {
+		b := Map{"<key>": String("123ms")}
+
+		v := MustGetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(v).To(Equal(123 * time.Millisecond))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := MustGetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(v).To(Equal(456 * time.Millisecond))
+	})
+
+	It("panics if the value cannot be parsed", func() {
+		b := Map{"<key>": String("<invalid>")}
+
+		Expect(func() {
+			MustGetDurationDefault(b, "<key>", 456*time.Millisecond)
+		}).To(PanicWith(
+			MatchError(`<key> is not a valid duration: time: invalid duration "<invalid>"`),
+		))
+	})
+})
+
+func ExampleMustGetDurationDefault() {
+	os.Setenv("FOO", "")
+
+	v := config.MustGetDurationDefault(config.Environment(), "FOO", 200*time.Millisecond)
+
+	fmt.Printf("the value is %s!\n", v)
+
+	// Output: the value is 200ms!
+}

--- a/config/duration_test.go
+++ b/config/duration_test.go
@@ -12,12 +12,21 @@ import (
 )
 
 var _ = Describe("func GetDuration()", func() {
-	It("returns a duration value", func() {
+	It("returns a positive duration value", func() {
 		b := Map{"<key>": String("123ms")}
 
 		v, ok, err := GetDuration(b, "<key>")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(Equal(123 * time.Millisecond))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative duration value", func() {
+		b := Map{"<key>": String("-123ms")}
+
+		v, ok, err := GetDuration(b, "<key>")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(Equal(-123 * time.Millisecond))
 		Expect(ok).To(BeTrue())
 	})
 
@@ -55,12 +64,20 @@ func ExampleGetDuration() {
 }
 
 var _ = Describe("func GetDurationDefault()", func() {
-	It("returns a duration value", func() {
+	It("returns a positive duration value", func() {
 		b := Map{"<key>": String("123ms")}
 
 		v, err := GetDurationDefault(b, "<key>", 456*time.Millisecond)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(v).To(Equal(123 * time.Millisecond))
+	})
+
+	It("returns a negative duration value", func() {
+		b := Map{"<key>": String("-123ms")}
+
+		v, err := GetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v).To(Equal(-123 * time.Millisecond))
 	})
 
 	It("returns the default value if the key is not defined", func() {
@@ -93,11 +110,19 @@ func ExampleGetDurationDefault() {
 }
 
 var _ = Describe("func MustGetDuration()", func() {
-	It("returns a duration value", func() {
+	It("returns a positive duration value", func() {
 		b := Map{"<key>": String("123ms")}
 
 		v, ok := MustGetDuration(b, "<key>")
 		Expect(v).To(Equal(123 * time.Millisecond))
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns a negative duration value", func() {
+		b := Map{"<key>": String("-123ms")}
+
+		v, ok := MustGetDuration(b, "<key>")
+		Expect(v).To(Equal(-123 * time.Millisecond))
 		Expect(ok).To(BeTrue())
 	})
 
@@ -134,11 +159,18 @@ func ExampleMustGetDuration() {
 }
 
 var _ = Describe("func MustGetDurationDefault()", func() {
-	It("returns a duration value", func() {
+	It("returns a positive duration value", func() {
 		b := Map{"<key>": String("123ms")}
 
 		v := MustGetDurationDefault(b, "<key>", 456*time.Millisecond)
 		Expect(v).To(Equal(123 * time.Millisecond))
+	})
+
+	It("returns a negative duration value", func() {
+		b := Map{"<key>": String("-123ms")}
+
+		v := MustGetDurationDefault(b, "<key>", 456*time.Millisecond)
+		Expect(v).To(Equal(-123 * time.Millisecond))
 	})
 
 	It("returns the default value if the key is not defined", func() {


### PR DESCRIPTION
Partially addresses #33 

This PR adds several new helper functions for reading configuration values from a `config.Bucket` and parsing them as `time.Duration` values.

