### PR TITLE
Add `config.AsURL()` and `AsURLDefault()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `config.AsURL()` and `AsURLDefault()`
+
 ## [1.0.0] - 2020-12-21
 
 This is the first stable release. There have been no changes to the API since

--- a/config/url.go
+++ b/config/url.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// AsURL returns the url.URL representation of the value associated with k or
+// panics if unable to do so.
+func AsURL(b Bucket, k string) *url.URL {
+	if v, ok := tryAsURL(b, k); ok {
+		return v
+	}
+
+	panic(fmt.Sprintf("%s is not defined", k))
+}
+
+// AsURLDefault returns the url.URL representation of the value associated with
+// k, or the default value v if k is undefined.
+func AsURLDefault(b Bucket, k, v string) *url.URL {
+	if v, ok := tryAsURL(b, k); ok {
+		return v
+	}
+
+	u, err := url.Parse(v)
+	if err != nil {
+		panic(fmt.Sprintf(
+			`expected the default value for %s to be a URL: %s`,
+			k,
+			err,
+		))
+	}
+
+	return u
+}
+
+func tryAsURL(
+	b Bucket,
+	k string,
+) (*url.URL, bool) {
+	x := b.Get(k)
+
+	if x.IsZero() {
+		return nil, false
+	}
+
+	v, err := url.Parse(mustAsString(k, x))
+	if err != nil {
+		panic(fmt.Sprintf(
+			`expected %s to be a URL: %s`,
+			k,
+			err,
+		))
+	}
+
+	return v, true
+}

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -1,0 +1,64 @@
+package config_test
+
+import (
+	. "github.com/dogmatiq/dodeca/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func AsURL()", func() {
+	It("returns a URL value", func() {
+		b := Map{"<key>": String("http://www.example.com/path")}
+
+		v := AsURL(b, "<key>")
+		Expect(v.String()).To(Equal("http://www.example.com/path"))
+	})
+
+	It("panics if the key is not defined", func() {
+		b := Map{}
+
+		Expect(func() {
+			AsURL(b, "<key>")
+		}).To(PanicWith(`<key> is not defined`))
+	})
+
+	It("panics if the value cannot be parsed", func() {
+		b := Map{"<key>": String(":")}
+
+		Expect(func() {
+			AsURL(b, "<key>")
+		}).To(PanicWith(`expected <key> to be a URL: parse ":": missing protocol scheme`))
+	})
+})
+
+var _ = Describe("func AsURLDefault()", func() {
+	It("returns a URL value", func() {
+		b := Map{"<key>": String("http://www.example.com/path")}
+
+		v := AsURLDefault(b, "<key>", "http://www.example.org/default")
+		Expect(v.String()).To(Equal("http://www.example.com/path"))
+	})
+
+	It("returns the default value if the key is not defined", func() {
+		b := Map{}
+
+		v := AsURLDefault(b, "<key>", "http://www.example.org/default")
+		Expect(v.String()).To(Equal("http://www.example.org/default"))
+	})
+
+	It("panics if the value cannot be parsed", func() {
+		b := Map{"<key>": String(":")}
+
+		Expect(func() {
+			AsURLDefault(b, "<key>", "http://www.example.org/default")
+		}).To(PanicWith(`expected <key> to be a URL: parse ":": missing protocol scheme`))
+	})
+
+	It("panics if the default value cannot be parsed", func() {
+		b := Map{}
+
+		Expect(func() {
+			AsURLDefault(b, "<key>", ":")
+		}).To(PanicWith(`expected the default value for <key> to be a URL: parse ":": missing protocol scheme`))
+	})
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `config.AsURL()` and `AsURLDefault()` functions.

#### Why make this change?

To easily obtain a `*url.URL` (especially in DI setup) without having to write parsing code each time.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
