### PR TITLE
Add `logging.Tee()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `logging.Tee()`, which returns a logger that dispatches all messages to multiple other loggers
+
 ## [1.2.0] - 2021-08-26
 
 ### Added

--- a/logging/tee.go
+++ b/logging/tee.go
@@ -1,0 +1,102 @@
+package logging
+
+// Tee returns a logger that forwards all messages to multiple target loggers.
+//
+// It panics if no targets are provided, ensuring that log messages are not lost
+// due to misconfiguration.
+//
+// The target list is de-duplicated, ensuring that log messages are not
+// repeatedly sent to the same logger. Two loggers are considered equal if they
+// compare the same using a regular shallow interface comparison via ==.
+//
+// Although the returned logger "wraps" the target loggers, it does not
+// implement Wrapper, as that interface does not support multiple loggers.
+func Tee(targets ...Logger) Logger {
+	if len(targets) == 0 {
+		panic("at least one target logger must be provided")
+	}
+
+	d := duplicator{}
+
+next:
+	for _, t := range targets {
+		for _, x := range d.Targets {
+			if x == t {
+				continue next
+			}
+		}
+
+		d.Targets = append(d.Targets, t)
+
+		if t.IsDebug() {
+			d.CaptureDebug = true
+		}
+	}
+
+	return d
+}
+
+// duplicator is a logger that forwards log messages to multiple loggers.
+type duplicator struct {
+	Targets      []Logger
+	CaptureDebug bool
+}
+
+// Log writes an application log message formatted according to a format
+// specifier.
+//
+// It should be used for messages that are intended for people responsible for
+// operating the application, such as the end-user or operations staff.
+//
+// f is the format specifier, as per fmt.Printf(), etc.
+func (d duplicator) Log(f string, v ...interface{}) {
+	for _, t := range d.Targets {
+		Log(t, f, v...)
+	}
+}
+
+// LogString writes a pre-formatted application log message.
+//
+// It should be used for messages that are intended for people responsible for
+// operating the application, such as the end-user or operations staff.
+func (d duplicator) LogString(s string) {
+	for _, t := range d.Targets {
+		LogString(t, s)
+	}
+}
+
+// Debug writes a debug log message formatted according to a format specifier.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software developers
+// that maintain the application.
+//
+// f is the format specifier, as per fmt.Printf(), etc.
+func (d duplicator) Debug(f string, v ...interface{}) {
+	for _, t := range d.Targets {
+		Debug(t, f, v...)
+	}
+}
+
+// DebugString writes a pre-formatted debug log message.
+//
+// If IsDebug() returns false, no logging is performed.
+//
+// It should be used for messages that are intended for the software developers
+// that maintain the application.
+func (d duplicator) DebugString(s string) {
+	for _, t := range d.Targets {
+		DebugString(t, s)
+	}
+}
+
+// IsDebug returns true if this logger will perform debug logging.
+//
+// Generally the application should just call Debug() or DebugString() without
+// calling IsDebug(), however it can be used to check if debug logging is
+// necessary before executing expensive code that is only used to obtain debug
+// information.
+func (d duplicator) IsDebug() bool {
+	return d.CaptureDebug
+}

--- a/logging/tee_test.go
+++ b/logging/tee_test.go
@@ -1,0 +1,114 @@
+package logging_test
+
+import (
+	. "github.com/dogmatiq/dodeca/logging"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func Tee()", func() {
+	var (
+		targetA, targetB, targetC *BufferedLogger
+		logger                    Logger
+	)
+
+	BeforeEach(func() {
+		targetA = &BufferedLogger{
+			CaptureDebug: true,
+		}
+
+		targetB = &BufferedLogger{
+			CaptureDebug: true,
+		}
+
+		targetC = &BufferedLogger{
+			CaptureDebug: false,
+		}
+
+		logger = Tee(targetA, targetB, targetC)
+	})
+
+	It("removes duplicate loggers", func() {
+		logger = Tee(targetA, targetA)
+		logger.Log("<message>")
+
+		Expect(targetA.Messages()).To(HaveLen(1))
+	})
+
+	It("panics if no target are provided", func() {
+		Expect(func() {
+			Tee()
+		}).To(PanicWith("at least one target logger must be provided"))
+	})
+
+	Describe("func Log()", func() {
+		It("forwards to the all targets", func() {
+			logger.Log("message <%s>", "arg")
+
+			x := BufferedLogMessage{
+				Message: "message <arg>",
+				IsDebug: false,
+			}
+
+			Expect(targetA.Messages()).To(ConsistOf(x))
+			Expect(targetB.Messages()).To(ConsistOf(x))
+			Expect(targetC.Messages()).To(ConsistOf(x))
+		})
+	})
+
+	Describe("func LogString()", func() {
+		It("forwards to all targets", func() {
+			logger.LogString("<message>")
+
+			x := BufferedLogMessage{
+				Message: "<message>",
+				IsDebug: false,
+			}
+
+			Expect(targetA.Messages()).To(ConsistOf(x))
+			Expect(targetB.Messages()).To(ConsistOf(x))
+			Expect(targetC.Messages()).To(ConsistOf(x))
+		})
+	})
+
+	Describe("func Debug()", func() {
+		It("forwards to all debug targets", func() {
+			logger.Debug("message <%s>", "arg")
+
+			x := BufferedLogMessage{
+				Message: "message <arg>",
+				IsDebug: true,
+			}
+
+			Expect(targetA.Messages()).To(ConsistOf(x))
+			Expect(targetB.Messages()).To(ConsistOf(x))
+			Expect(targetC.Messages()).To(BeEmpty())
+		})
+	})
+
+	Describe("func DebugString()", func() {
+		It("forwards to all targets", func() {
+			logger.DebugString("<message>")
+
+			x := BufferedLogMessage{
+				Message: "<message>",
+				IsDebug: true,
+			}
+
+			Expect(targetA.Messages()).To(ConsistOf(x))
+			Expect(targetB.Messages()).To(ConsistOf(x))
+			Expect(targetC.Messages()).To(BeEmpty())
+		})
+	})
+
+	Describe("func IsDebug()", func() {
+		It("returns true if any target captures debug messages", func() {
+			Expect(logger.IsDebug()).To(BeTrue())
+		})
+
+		It("returns false if none of the targets capture debug messages", func() {
+			logger = Tee(targetC)
+			Expect(logger.IsDebug()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `logging.Tee()` function, which forwards log messages to multiple other target loggers.

#### Why make this change?

I need a mechanism to write log messages to multiple targets (a general server log, and a per-request log).

#### Is there anything you are unsure about?

There is a `Wrapper` interface which is typically implemented by any `Logger` implementation that wraps other loggers, but it does not support a logger that wraps _multiple_ loggers. The `Tee()` logger does not implement this interface, which I have documented.

#### What issues does this relate to?

None
