### PR TITLE
Change `StreamWriter` to support various line terminating characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Fixed
+
+- `logging.StreamWriter` now correctly handles Windows newlines (CRLF)
+- `logging.StreamWriter` now treats a single CR character as a newline
+
 ## [1.3.0] - 2022-01-02
 
 ### Added

--- a/logging/writer.go
+++ b/logging/writer.go
@@ -8,10 +8,13 @@ import (
 
 // StreamWriter is an adaptor that presents a Logger as an io.WriteCloser.
 //
-// Each LF (line-feed) terminated line of text written via Write() is logged as
-// a separate message. Any call to write with text that does not end in LF is
-// buffered until a LF is encountered in a subsequent call to Write(), or
-// Close() is called.
+// Each line of text written via Write() is logged as a separate message. Any
+// call to write with text that does not end in line separator is buffered until
+// a line separator is written or Close() is called. Blank lines are ignored.
+//
+// Any instance of a LF, CR or CRLF is treated as a line separator. This allows
+// usage with Unix-style or Windows-style text output, as well as console output
+// that uses CR to overwrite the current line.
 type StreamWriter struct {
 	// Target is the logger that receives the log messages.
 	Target Logger
@@ -26,21 +29,31 @@ func (w *StreamWriter) Write(data []byte) (int, error) {
 	w.m.Lock()
 	defer w.m.Unlock()
 
-	i := bytes.IndexRune(data, '\n')
-	for i != -1 {
-		w.buf.Write(data[:i])
-		LogString(w.Target, w.buf.String())
-		w.buf.Reset()
+	for {
+		i := bytes.IndexAny(data, "\r\n")
 
+		// No CRs or LFs in the string, write the remaining unterminated line
+		// (if any) to the buffer.
+		if i == -1 {
+			w.buf.Write(data)
+			return n, nil
+		}
+
+		// Write the data up to the line separator to the buffer (in case it's
+		// the tail end of some longer line), then flush the entire line to the
+		// logger.
+		w.buf.Write(data[:i])
+		w.flush()
+
+		sep := data[i]
 		data = data[i+1:]
 
-		i = bytes.IndexRune(data, '\n')
+		// If we've found a Windows-style new line (CRLF) we need to consume the
+		// extra byte too.
+		if sep == '\r' && len(data) > 0 && data[0] == '\n' {
+			data = data[1:]
+		}
 	}
-
-	// Write the remaining data, if any, into the temporary string buffer
-	w.buf.Write(data)
-
-	return n, nil
 }
 
 // Close closes the writer, producing a log message from any remaining buffered
@@ -49,12 +62,20 @@ func (w *StreamWriter) Close() error {
 	w.m.Lock()
 	defer w.m.Unlock()
 
+	w.flush()
+
+	return nil
+}
+
+// flush writes the contents of w.buf to the log.
+//
+// An empty buffer is never flushed to the log, which has the effect of removing
+// blank lines from the output.
+func (w *StreamWriter) flush() {
 	if w.buf.Len() > 0 {
 		LogString(w.Target, w.buf.String())
 		w.buf.Reset()
 	}
-
-	return nil
 }
 
 // LineWriter is an adaptor that presents a Logger as an io.Writer.


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes `logging.StreamWriter` to treat any of LF (`\n`), CR (`\r`) or CRLF (`\r\n`) as line terminators.

#### Why make this change?

It's fairly common for CLI commands to output a CR in order to overwrite the current line of text. Prior to this PR, these characters were not being treated as newlines, resulting in garbled log messages with partially overwritten text.

After this change, each "overwritten" line appears as its own log message.

As an additional benefit, windows style newlines are now handled properly without the trailing CR appearing in the log message itself.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
